### PR TITLE
Upgrade to .NET 10 with Duende IdentityServer migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,9 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# Duende IdentityServer signing keys
+**/keys/
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,7 @@ MigrationBackup/
 FodyWeavers.xsd
 # Duende IdentityServer signing keys
 **/keys/
+tempkey.jwk
 
 # Claude Code
 CLAUDE.md

--- a/Timinute/Client/Program.cs
+++ b/Timinute/Client/Program.cs
@@ -21,6 +21,12 @@ builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().Cre
 builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<DialogService>();
 
-builder.Services.AddApiAuthorization();
+builder.Services.AddOidcAuthentication(options =>
+{
+    options.ProviderOptions.Authority = builder.HostEnvironment.BaseAddress;
+    options.ProviderOptions.ClientId = "Timinute.Client";
+    options.ProviderOptions.ResponseType = "code";
+    options.ProviderOptions.DefaultScopes.Add("Timinute.ServerAPI");
+});
 
 await builder.Build().RunAsync();

--- a/Timinute/Client/Program.cs
+++ b/Timinute/Client/Program.cs
@@ -23,7 +23,7 @@ builder.Services.AddScoped<DialogService>();
 
 builder.Services.AddOidcAuthentication(options =>
 {
-    options.ProviderOptions.Authority = builder.HostEnvironment.BaseAddress;
+    options.ProviderOptions.Authority = builder.HostEnvironment.BaseAddress.TrimEnd('/');
     options.ProviderOptions.ClientId = "Timinute.Client";
     options.ProviderOptions.ResponseType = "code";
     options.ProviderOptions.DefaultScopes.Add("Timinute.ServerAPI");

--- a/Timinute/Client/Timinute.Client.csproj
+++ b/Timinute/Client/Timinute.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>

--- a/Timinute/Client/Timinute.Client.csproj
+++ b/Timinute/Client/Timinute.Client.csproj
@@ -9,12 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Radzen.Blazor" Version="5.4.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Radzen.Blazor" Version="10.1.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Timinute/Client/wwwroot/service-worker.published.js
+++ b/Timinute/Client/wwwroot/service-worker.published.js
@@ -20,9 +20,6 @@ async function onInstall(event) {
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, { integrity: asset.hash, cache: 'no-cache' }));
 
-    // Also cache authentication configuration
-    assetsRequests.push(new Request('_configuration/Timinute.Client'));
-
     await caches.open(cacheName).then(cache => cache.addAll(assetsRequests));
 }
 

--- a/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
@@ -88,6 +88,25 @@ namespace Timinute.Server.Tests.Controllers
         }
 
         [Fact]
+        public async Task Get_Work_Time_Per_Months_Test()
+        {
+            AnalyticsController controller = await CreateController();
+
+            var actionResult = await controller.GetWorkTimePerMonths();
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+
+            Assert.NotNull(okResult);
+            Assert.IsAssignableFrom<List<WorkTimePerMonthDto>>(okResult!.Value);
+            var workTimePerMonths = okResult.Value as List<WorkTimePerMonthDto>;
+
+            Assert.NotNull(workTimePerMonths);
+            Assert.Equal(2, workTimePerMonths!.Count);
+        }
+
+        [Fact]
         public async Task Get_Work_Time_Per_Months()
         {
             AnalyticsController controller = await CreateController();

--- a/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
@@ -104,6 +104,19 @@ namespace Timinute.Server.Tests.Controllers
 
             Assert.NotNull(workTimePerMonths);
             Assert.Equal(2, workTimePerMonths!.Count);
+
+            var thisMonth = DateTime.UtcNow;
+            var lastMonth = thisMonth.AddMonths(-1);
+            var thisMonthLabel = new DateTime(thisMonth.Year, thisMonth.Month, 1).ToString("yyyy MMM");
+            var lastMonthLabel = new DateTime(lastMonth.Year, lastMonth.Month, 1).ToString("yyyy MMM");
+
+            Assert.Contains(workTimePerMonths, w =>
+                w.Time == thisMonthLabel &&
+                w.WorkTimeInSeconds == TimeSpan.FromHours(10).TotalSeconds);
+
+            Assert.Contains(workTimePerMonths, w =>
+                w.Time == lastMonthLabel &&
+                w.WorkTimeInSeconds == TimeSpan.FromHours(28).TotalSeconds);
         }
 
         [Fact]

--- a/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
@@ -25,8 +25,9 @@ namespace Timinute.Server.Tests.Controllers
 
         public AnalyticsControllerTest()
         {
-            var myProfile = new MappingProfile();
-            var configuration = new MapperConfiguration(cfg => cfg.AddProfile(myProfile));
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
             _mapper = new Mapper(configuration);
 
             _loggerMock = new Mock<ILogger<AnalyticsController>>();

--- a/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
@@ -38,7 +38,7 @@ namespace Timinute.Server.Tests.Controllers
         {
             AnalyticsController controller = await CreateController();
 
-            DateTime lastMonth = DateTime.Now.AddMonths(-1);
+            DateTime lastMonth = DateTime.UtcNow.AddMonths(-1);
 
             var actionResult = await controller.GetAmountWorkTimeByMonth(new AmountWorkTimeByMonthDto { Year = lastMonth.Year, Month = lastMonth.Month });
 
@@ -65,7 +65,7 @@ namespace Timinute.Server.Tests.Controllers
         {
             AnalyticsController controller = await CreateController();
 
-            DateTime thisMonth = DateTime.Now;
+            DateTime thisMonth = DateTime.UtcNow;
 
             var actionResult = await controller.GetAmountWorkTimeByMonth(new AmountWorkTimeByMonthDto { Year = thisMonth.Year, Month = thisMonth.Month });
 

--- a/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
@@ -27,8 +27,9 @@ namespace Timinute.Server.Tests.Controllers
         private const string _databaseName = "ProjectController_Test_DB";
         public ProjectControllerTest()
         {
-            var myProfile = new MappingProfile();
-            var configuration = new MapperConfiguration(cfg => cfg.AddProfile(myProfile));
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
             _mapper = new Mapper(configuration);
 
             _loggerMock = new Mock<ILogger<ProjectController>>();

--- a/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
@@ -233,6 +233,19 @@ namespace Timinute.Server.Tests.Controllers
             Assert.Equal(projectToCreate.Name, newlyCreatedProject!.Name);
         }
 
+        [Fact]
+        public async Task Delete_Project_Another_User_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteAuthTest");
+            ProjectController controller = await CreateController(applicationDbContext, "ApplicationUser10");
+
+            // Try to delete ApplicationUser1's project
+            var actionResult = await controller.DeleteProject("ProjectId1");
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<UnauthorizedResult>(actionResult);
+        }
+
         protected override async Task<ProjectController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
         {
             if (applicationDbContext == null)

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -279,6 +279,29 @@ namespace Timinute.Server.Tests.Controllers
             Assert.Equal(trackedTaskToCreate.Duration, newlyCreatedTrackedTask!.Duration);
         }
 
+        [Fact]
+        public async Task Update_TrackedTask_Another_User_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateAuthTest");
+            TrackedTaskController controller = await CreateController(applicationDbContext, "ApplicationUser2");
+
+            var trackedTaskToUpdate = new UpdateTrackedTaskDto
+            {
+                TaskId = "TrackedTaskId1",  // belongs to ApplicationUser1
+                Name = "Hacked Name",
+                StartDate = DateTime.UtcNow,
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(trackedTaskToUpdate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<UnauthorizedResult>(actionResult.Result);
+
+            var unauthorizedResult = actionResult.Result as UnauthorizedResult;
+            Assert.NotNull(unauthorizedResult);
+            Assert.Equal((int)System.Net.HttpStatusCode.Unauthorized, unauthorizedResult!.StatusCode);
+        }
+
         protected override async Task<TrackedTaskController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
         {
             if (applicationDbContext == null)
@@ -289,7 +312,7 @@ namespace Timinute.Server.Tests.Controllers
             var repositoryFactory = new RepositoryFactory(applicationDbContext);
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {
-                                        new Claim("sub", "ApplicationUser1"),
+                                        new Claim("sub", userId),
                                         new Claim(ClaimTypes.Name, "test1@email.com")
                                         }
             ));

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -27,8 +27,9 @@ namespace Timinute.Server.Tests.Controllers
         private const string _databaseName = "TrackedTaskController_Test_DB";
         public TrackedTaskControllerTest()
         {
-            var myProfile = new MappingProfile();
-            var configuration = new MapperConfiguration(cfg => cfg.AddProfile(myProfile));
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
             _mapper = new Mapper(configuration);
 
             _loggerMock = new Mock<ILogger<TrackedTaskController>>();

--- a/Timinute/Server.Tests/Helpers/TestHelper.cs
+++ b/Timinute/Server.Tests/Helpers/TestHelper.cs
@@ -98,9 +98,9 @@ namespace Timinute.Server.Tests.Helpers
                 new ApplicationUser { Id = "ApplicationUser1000", Email = "test1000@email.com", FirstName = "Jan", LastName = "Testovic", EmailConfirmed = true, UserName = "janek100", PasswordHash = "3037c1616052562ebec4291009d17541"},
             };
 
-            var now = DateTime.Now;
-            var month = new DateTime(now.Year, now.Month, 1).ToUniversalTime();
-            var first = new DateTime(now.Year, now.Month, 1).AddMonths(-1).ToUniversalTime();
+            var now = DateTime.UtcNow;
+            var month = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+            var first = month.AddMonths(-1);
 
             var projects = new List<Project>
             {

--- a/Timinute/Server.Tests/Helpers/TestHelper.cs
+++ b/Timinute/Server.Tests/Helpers/TestHelper.cs
@@ -98,34 +98,39 @@ namespace Timinute.Server.Tests.Helpers
                 new ApplicationUser { Id = "ApplicationUser1000", Email = "test1000@email.com", FirstName = "Jan", LastName = "Testovic", EmailConfirmed = true, UserName = "janek100", PasswordHash = "3037c1616052562ebec4291009d17541"},
             };
 
-            var today = DateTime.Today.ToUniversalTime();
-            var month = new DateTime(today.Year, today.Month, 1).ToUniversalTime();
-            var first = month.AddMonths(-1);
-
-            var trackedTasks = new List<TrackedTask>
-            {
-                new TrackedTask { TaskId = "TrackedTaskId1001", Name = "Task 1001", ProjectId = "ProjectId1001", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(1), Duration = TimeSpan.FromHours(1) },
-                new TrackedTask { TaskId = "TrackedTaskId1002", Name = "Task 1002", ProjectId = "ProjectId1001", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(2), Duration = TimeSpan.FromHours(2) },
-                new TrackedTask { TaskId = "TrackedTaskId1003", Name = "Task 1003", ProjectId = "ProjectId1002", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(3), Duration = TimeSpan.FromHours(3) },
-                new TrackedTask { TaskId = "TrackedTaskId1004", Name = "Task 1004", ProjectId = "ProjectId1002", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(4), Duration = TimeSpan.FromHours(4) },
-                new TrackedTask { TaskId = "TrackedTaskId1005", Name = "Task 1005", ProjectId = "ProjectId1003", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(5), Duration = TimeSpan.FromHours(5) },
-                new TrackedTask { TaskId = "TrackedTaskId1006", Name = "Task 1006", ProjectId = "ProjectId1003", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(6), Duration = TimeSpan.FromHours(6) },
-
-                new TrackedTask { TaskId = "TrackedTaskId1007", Name = "Task 1007", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(7), Duration = TimeSpan.FromHours(7) },
-
-                new TrackedTask { TaskId = "TrackedTaskId1008", Name = "Task 1008", User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(1), Duration = TimeSpan.FromHours(1) },
-                new TrackedTask { TaskId = "TrackedTaskId1009", Name = "Task 1009", User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(2), Duration = TimeSpan.FromHours(2) },
-                new TrackedTask { TaskId = "TrackedTaskId1010", Name = "Task 1010", User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(3), Duration = TimeSpan.FromHours(3) },
-                new TrackedTask { TaskId = "TrackedTaskId1011", Name = "Task 1011", User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(4), Duration = TimeSpan.FromHours(4) },
-            };
+            var now = DateTime.Now;
+            var month = new DateTime(now.Year, now.Month, 1).ToUniversalTime();
+            var first = new DateTime(now.Year, now.Month, 1).AddMonths(-1).ToUniversalTime();
 
             var projects = new List<Project>
             {
-                new Project { ProjectId = "ProjectId1001", Name = "Project 1001", UserId = applicationUsers[0].Id, TrackedTasks = new List<TrackedTask>() { trackedTasks[0], trackedTasks[1] } },
-                new Project { ProjectId = "ProjectId1002", Name = "Project 1002", UserId = applicationUsers[0].Id, TrackedTasks = new List<TrackedTask>() { trackedTasks[2], trackedTasks[3] } },
-                new Project { ProjectId = "ProjectId1003", Name = "Project 1003", UserId = applicationUsers[0].Id, TrackedTasks = new List<TrackedTask>() { trackedTasks[4], trackedTasks[5] } },
-                new Project { ProjectId = "ProjectId1004", Name = "Project 1004", UserId = applicationUsers[0].Id, TrackedTasks = new List<TrackedTask>() { trackedTasks[7], trackedTasks[8], trackedTasks[9], trackedTasks[10], } },
+                new Project { ProjectId = "ProjectId1001", Name = "Project 1001", UserId = applicationUsers[0].Id },
+                new Project { ProjectId = "ProjectId1002", Name = "Project 1002", UserId = applicationUsers[0].Id },
+                new Project { ProjectId = "ProjectId1003", Name = "Project 1003", UserId = applicationUsers[0].Id },
+                new Project { ProjectId = "ProjectId1004", Name = "Project 1004", UserId = applicationUsers[0].Id },
             };
+
+            var trackedTasks = new List<TrackedTask>
+            {
+                new TrackedTask { TaskId = "TrackedTaskId1001", Name = "Task 1001", Project = projects[0], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(1), Duration = TimeSpan.FromHours(1) },
+                new TrackedTask { TaskId = "TrackedTaskId1002", Name = "Task 1002", Project = projects[0], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(2), Duration = TimeSpan.FromHours(2) },
+                new TrackedTask { TaskId = "TrackedTaskId1003", Name = "Task 1003", Project = projects[1], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(3), Duration = TimeSpan.FromHours(3) },
+                new TrackedTask { TaskId = "TrackedTaskId1004", Name = "Task 1004", Project = projects[1], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(4), Duration = TimeSpan.FromHours(4) },
+                new TrackedTask { TaskId = "TrackedTaskId1005", Name = "Task 1005", Project = projects[2], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(5), Duration = TimeSpan.FromHours(5) },
+                new TrackedTask { TaskId = "TrackedTaskId1006", Name = "Task 1006", Project = projects[2], User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(6), Duration = TimeSpan.FromHours(6) },
+
+                new TrackedTask { TaskId = "TrackedTaskId1007", Name = "Task 1007", User = applicationUsers[0], StartDate = first, EndDate = first.AddHours(7), Duration = TimeSpan.FromHours(7) },
+
+                new TrackedTask { TaskId = "TrackedTaskId1008", Name = "Task 1008", Project = projects[3], User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(1), Duration = TimeSpan.FromHours(1) },
+                new TrackedTask { TaskId = "TrackedTaskId1009", Name = "Task 1009", Project = projects[3], User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(2), Duration = TimeSpan.FromHours(2) },
+                new TrackedTask { TaskId = "TrackedTaskId1010", Name = "Task 1010", Project = projects[3], User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(3), Duration = TimeSpan.FromHours(3) },
+                new TrackedTask { TaskId = "TrackedTaskId1011", Name = "Task 1011", Project = projects[3], User = applicationUsers[0], StartDate = month, EndDate = month.AddHours(4), Duration = TimeSpan.FromHours(4) },
+            };
+
+            projects[0].TrackedTasks = new List<TrackedTask>() { trackedTasks[0], trackedTasks[1] };
+            projects[1].TrackedTasks = new List<TrackedTask>() { trackedTasks[2], trackedTasks[3] };
+            projects[2].TrackedTasks = new List<TrackedTask>() { trackedTasks[4], trackedTasks[5] };
+            projects[3].TrackedTasks = new List<TrackedTask>() { trackedTasks[7], trackedTasks[8], trackedTasks[9], trackedTasks[10] };
 
             context.Users.AddRange(applicationUsers);
             context.TrackedTasks.AddRange(trackedTasks);

--- a/Timinute/Server.Tests/Helpers/TestHelper.cs
+++ b/Timinute/Server.Tests/Helpers/TestHelper.cs
@@ -1,6 +1,4 @@
-﻿using Duende.IdentityServer.EntityFramework.Options;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -24,11 +22,9 @@ namespace Timinute.Server.Tests.Helpers
 
         public static async Task<ApplicationDbContext> GetDefaultApplicationDbContext(string databaseName = "Test_DB", bool fillTestDate = true, bool deleteAll = true, bool analyticsTest = false)
         {
-            var someOptions = Options.Create(new OperationalStoreOptions());
-
             var dbContextOptions = GetDbContextOptions(databaseName);
 
-            var context = new ApplicationDbContext(dbContextOptions, someOptions);
+            var context = new ApplicationDbContext(dbContextOptions);
 
             if (deleteAll)
             {

--- a/Timinute/Server.Tests/Repositories/ProjectRepositoryTest.cs
+++ b/Timinute/Server.Tests/Repositories/ProjectRepositoryTest.cs
@@ -36,7 +36,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_Project_By_ProjectId_Test()
+        public async Task Get_Project_By_ProjectId_Test()
         {
             await using (var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName))
             {
@@ -51,7 +51,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_Project_Where_ProjectId_Test()
+        public async Task Get_Project_Where_ProjectId_Test()
         {
             using (var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName))
             {
@@ -66,7 +66,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_Project_By_Name_Test()
+        public async Task Get_Project_By_Name_Test()
         {
             using (var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName))
             {

--- a/Timinute/Server.Tests/Repositories/ProjectRepositoryTest.cs
+++ b/Timinute/Server.Tests/Repositories/ProjectRepositoryTest.cs
@@ -169,5 +169,32 @@ namespace Timinute.Server.Tests.Repositories
                 await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await repository.Update(trackedTaskToUpdate));
             }
         }
+
+        [Fact]
+        public async Task Delete_Existing_Project_Test()
+        {
+            await using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
+            var repository = new BaseRepository<Project>(dbContext);
+
+            var project = await repository.GetById("ProjectId4");
+            Assert.NotNull(project);
+
+            await repository.Delete(project!);
+
+            var deleted = await repository.GetById("ProjectId4");
+            Assert.Null(deleted);
+        }
+
+        [Fact]
+        public async Task Delete_Project_By_Id_Test()
+        {
+            await using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
+            var repository = new BaseRepository<Project>(dbContext);
+
+            await repository.Delete("ProjectId5");
+
+            var deleted = await repository.GetById("ProjectId5");
+            Assert.Null(deleted);
+        }
     }
 }

--- a/Timinute/Server.Tests/Repositories/TrackedTaskRepositoryTest.cs
+++ b/Timinute/Server.Tests/Repositories/TrackedTaskRepositoryTest.cs
@@ -41,7 +41,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_TrackedTask_By_TaskId_Test()
+        public async Task Get_TrackedTask_By_TaskId_Test()
         {
             await using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
 
@@ -55,7 +55,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_TrackedTask_Where_TaskId_Test()
+        public async Task Get_TrackedTask_Where_TaskId_Test()
         {
             using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
 
@@ -69,7 +69,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_TrackedTask_By_Name_Test()
+        public async Task Get_TrackedTask_By_Name_Test()
         {
             using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
 
@@ -83,7 +83,7 @@ namespace Timinute.Server.Tests.Repositories
         }
 
         [Fact]
-        public async void Get_TrackedTask_By_Duration_Test()
+        public async Task Get_TrackedTask_By_Duration_Test()
         {
             using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
 

--- a/Timinute/Server.Tests/Repositories/TrackedTaskRepositoryTest.cs
+++ b/Timinute/Server.Tests/Repositories/TrackedTaskRepositoryTest.cs
@@ -173,6 +173,33 @@ namespace Timinute.Server.Tests.Repositories
 
             await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await repository.Update(trackedTaskToUpdate));
         }
+
+        [Fact]
+        public async Task Delete_Existing_TrackedTask_Test()
+        {
+            await using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
+            var repository = new BaseRepository<TrackedTask>(dbContext);
+
+            var task = await repository.GetById("TrackedTaskId1");
+            Assert.NotNull(task);
+
+            await repository.Delete(task!);
+
+            var deleted = await repository.GetById("TrackedTaskId1");
+            Assert.Null(deleted);
+        }
+
+        [Fact]
+        public async Task Delete_TrackedTask_By_Id_Test()
+        {
+            await using var dbContext = await TestHelper.GetDefaultApplicationDbContext(dbName);
+            var repository = new BaseRepository<TrackedTask>(dbContext);
+
+            await repository.Delete("TrackedTaskId2");
+
+            var deleted = await repository.GetById("TrackedTaskId2");
+            Assert.Null(deleted);
+        }
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
     }
 }

--- a/Timinute/Server.Tests/Timinute.Server.Tests.csproj
+++ b/Timinute/Server.Tests/Timinute.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/Timinute/Server.Tests/Timinute.Server.Tests.csproj
+++ b/Timinute/Server.Tests/Timinute.Server.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Timinute/Server/Areas/Identity/ApplicationUserClaimsPrincipalFactory.cs
+++ b/Timinute/Server/Areas/Identity/ApplicationUserClaimsPrincipalFactory.cs
@@ -28,13 +28,6 @@ namespace Timinute.Server.Areas.Identity
                 new Claim(Constants.Claims.LastLogin, user.LastLoginDate.HasValue ? user.LastLoginDate.Value.ToString("HH:mm dd/MM/yyyy") : string.Empty),
             });
 
-            var roles = await userManager.GetRolesAsync(user);
-
-            foreach (var role in roles)
-            {
-                claims.AddClaim(new Claim(Constants.Claims.Role, role));
-            }
-
             return claims;
         }
     }

--- a/Timinute/Server/Areas/Identity/ApplicationUserClaimsPrincipalFactory.cs
+++ b/Timinute/Server/Areas/Identity/ApplicationUserClaimsPrincipalFactory.cs
@@ -25,7 +25,7 @@ namespace Timinute.Server.Areas.Identity
             claims.AddClaims(new List<Claim>
             {
                 new Claim(Constants.Claims.Fullname, $"{user.FirstName} {user.LastName}"),
-                new Claim(Constants.Claims.LastLogin, user.LastLoginDate.HasValue ? user.LastLoginDate.Value.ToString("hh:mm dd/mm/yyyy") : string.Empty),
+                new Claim(Constants.Claims.LastLogin, user.LastLoginDate.HasValue ? user.LastLoginDate.Value.ToString("HH:mm dd/MM/yyyy") : string.Empty),
             });
 
             var roles = await userManager.GetRolesAsync(user);

--- a/Timinute/Server/Controllers/OidcConfigurationController.cs
+++ b/Timinute/Server/Controllers/OidcConfigurationController.cs
@@ -1,3 +1,0 @@
-// This controller has been removed as Duende IdentityServer exposes
-// /.well-known/openid-configuration automatically.
-// The file is kept empty to avoid dangling references; it can be deleted.

--- a/Timinute/Server/Controllers/OidcConfigurationController.cs
+++ b/Timinute/Server/Controllers/OidcConfigurationController.cs
@@ -1,25 +1,3 @@
-﻿using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
-using Microsoft.AspNetCore.Mvc;
-
-namespace Timinute.Server.Controllers
-{
-    public class OidcConfigurationController : Controller
-    {
-        private readonly ILogger<OidcConfigurationController> _logger;
-
-        public OidcConfigurationController(IClientRequestParametersProvider clientRequestParametersProvider, ILogger<OidcConfigurationController> logger)
-        {
-            ClientRequestParametersProvider = clientRequestParametersProvider;
-            _logger = logger;
-        }
-
-        public IClientRequestParametersProvider ClientRequestParametersProvider { get; }
-
-        [HttpGet("_configuration/{clientId}")]
-        public IActionResult GetClientRequestParameters([FromRoute] string clientId)
-        {
-            var parameters = ClientRequestParametersProvider.GetClientParameters(HttpContext, clientId);
-            return Ok(parameters);
-        }
-    }
-}
+// This controller has been removed as Duende IdentityServer exposes
+// /.well-known/openid-configuration automatically.
+// The file is kept empty to avoid dangling references; it can be deleted.

--- a/Timinute/Server/Data/ApplicationDbContext.cs
+++ b/Timinute/Server/Data/ApplicationDbContext.cs
@@ -1,22 +1,18 @@
-﻿using Duende.IdentityServer.EntityFramework.Options;
-using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using Timinute.Server.Helpers;
 using Timinute.Server.Models;
 
 namespace Timinute.Server.Data
 {
-    public class ApplicationDbContext : ApiAuthorizationDbContext<ApplicationUser>
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser, ApplicationRole, string>
     {
         public DbSet<ApplicationUser> ApplicationUsers { get; set; }
         public DbSet<ApplicationRole> ApplicationRoles { get; set; }
         public DbSet<TrackedTask> TrackedTasks { get; set; } = null!;
         public DbSet<Project> Projects { get; set; } = null!;
 
-        public ApplicationDbContext(
-            DbContextOptions options,
-            IOptions<OperationalStoreOptions> operationalStoreOptions) : base(options, operationalStoreOptions)
+        public ApplicationDbContext(DbContextOptions options) : base(options)
         {
         }
 

--- a/Timinute/Server/Data/ApplicationDbContext.cs
+++ b/Timinute/Server/Data/ApplicationDbContext.cs
@@ -7,8 +7,6 @@ namespace Timinute.Server.Data
 {
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser, ApplicationRole, string>
     {
-        public DbSet<ApplicationUser> ApplicationUsers { get; set; }
-        public DbSet<ApplicationRole> ApplicationRoles { get; set; }
         public DbSet<TrackedTask> TrackedTasks { get; set; } = null!;
         public DbSet<Project> Projects { get; set; } = null!;
 

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -77,7 +77,7 @@ builder.Services.AddControllers(options =>
 DependecyInjection();
 
 // Auto Mapper Configurations
-AutoMapperConfiguration();
+builder.Services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
 
 // Swagger Configuration
 SwaggerSetup();
@@ -200,15 +200,6 @@ void DependecyInjection()
     builder.Services.AddTransient<IRepositoryFactory, RepositoryFactory>();
 }
 
-void AutoMapperConfiguration()
-{
-    var mappingConfig = new MapperConfiguration(mc =>
-    {
-        mc.AddProfile(new MappingProfile());
-    });
-
-    builder.Services.AddSingleton(mappingConfig.CreateMapper());
-}
 
 void SwaggerSetup()
 {

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,5 +1,5 @@
 using AutoMapper;
-using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -26,7 +26,11 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 IdentitySetup();
 
 builder.Services.AddAuthentication()
-    .AddIdentityServerJwt();
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://localhost:7047";
+        options.TokenValidationParameters.ValidateAudience = false;
+    });
 
 builder.Logging.AddConsole();
 
@@ -154,14 +158,34 @@ void IdentitySetup()
         options.ClaimsIdentity.RoleClaimType = ClaimTypes.Role;
     });
 
-    builder.Services.AddIdentityServer()
-        .AddApiAuthorization<ApplicationUser, ApplicationDbContext>(options =>
+    builder.Services.AddIdentityServer(options =>
+    {
+        options.IssuerUri = "https://localhost:7047";
+    })
+        .AddAspNetIdentity<ApplicationUser>()
+        .AddInMemoryIdentityResources(new List<Duende.IdentityServer.Models.IdentityResource>
         {
-            options.IdentityResources["openid"].UserClaims.Add(Constants.Claims.Fullname);
-            options.IdentityResources["openid"].UserClaims.Add(Constants.Claims.LastLogin);
-            options.IdentityResources["openid"].UserClaims.Add(Constants.Claims.Role);
+            new Duende.IdentityServer.Models.IdentityResources.OpenId(),
+            new Duende.IdentityServer.Models.IdentityResources.Profile(),
         })
-        .AddJwtBearerClientAuthentication();
+        .AddInMemoryApiScopes(new List<Duende.IdentityServer.Models.ApiScope>
+        {
+            new Duende.IdentityServer.Models.ApiScope("Timinute.ServerAPI", "Timinute Server API")
+        })
+        .AddInMemoryClients(new List<Duende.IdentityServer.Models.Client>
+        {
+            new Duende.IdentityServer.Models.Client
+            {
+                ClientId = "Timinute.Client",
+                AllowedGrantTypes = Duende.IdentityServer.Models.GrantTypes.Code,
+                RequirePkce = true,
+                RequireClientSecret = false,
+                AllowedCorsOrigins = { "https://localhost:7047" },
+                AllowedScopes = { "openid", "profile", "Timinute.ServerAPI" },
+                RedirectUris = { "https://localhost:7047/authentication/login-callback" },
+                PostLogoutRedirectUris = { "https://localhost:7047/authentication/logout-callback" },
+            }
+        });
 }
 
 void DependecyInjection()

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -184,6 +184,13 @@ void IdentitySetup()
         {
             new ApiScope("Timinute.ServerAPI", "Timinute Server API")
         })
+        .AddInMemoryApiResources(new List<ApiResource>
+        {
+            new ApiResource("Timinute.ServerAPI", "Timinute Server API")
+            {
+                Scopes = { "Timinute.ServerAPI" }
+            }
+        })
         .AddInMemoryClients(new List<Client>
         {
             new Client

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -27,8 +27,8 @@ IdentitySetup();
 
 builder.Services.AddAuthentication(options =>
     {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultScheme = "ApplicationDefinedPolicy";
+        options.DefaultChallengeScheme = "ApplicationDefinedPolicy";
     })
     .AddJwtBearer(options =>
     {
@@ -37,6 +37,17 @@ builder.Services.AddAuthentication(options =>
         options.MapInboundClaims = false;
         options.TokenValidationParameters.NameClaimType = "name";
         options.TokenValidationParameters.RoleClaimType = Constants.Claims.Role;
+    })
+    .AddPolicyScheme("ApplicationDefinedPolicy", "ApplicationDefinedPolicy", options =>
+    {
+        options.ForwardDefaultSelector = context =>
+        {
+            string? authorization = context.Request.Headers.Authorization;
+            if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Bearer "))
+                return JwtBearerDefaults.AuthenticationScheme;
+
+            return IdentityConstants.ApplicationScheme;
+        };
     });
 
 builder.Logging.AddConsole();

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -210,6 +210,15 @@ void IdentitySetup()
     {
         identityServerBuilder.AddDeveloperSigningCredential();
     }
+    else
+    {
+        // Duende IdentityServer enables automatic key management by default.
+        // Keys are generated, rotated, and persisted to the /keys directory.
+        identityServerBuilder.Services.Configure<Duende.IdentityServer.Configuration.KeyManagementOptions>(options =>
+        {
+            options.Enabled = true;
+        });
+    }
 }
 
 void DependecyInjection()

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -134,7 +134,6 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseIdentityServer();
-app.UseAuthentication();
 app.UseAuthorization();
 
 
@@ -173,7 +172,7 @@ void IdentitySetup()
     {
         options.ClaimsIdentity.UserIdClaimType = ClaimTypes.NameIdentifier;
         options.ClaimsIdentity.UserNameClaimType = ClaimTypes.Name;
-        options.ClaimsIdentity.RoleClaimType = ClaimTypes.Role;
+        options.ClaimsIdentity.RoleClaimType = Constants.Claims.Role;
     });
 
     var baseUrl = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -36,7 +36,7 @@ builder.Services.AddAuthentication(options =>
         options.Audience = "Timinute.ServerAPI";
         options.MapInboundClaims = false;
         options.TokenValidationParameters.NameClaimType = "name";
-        options.TokenValidationParameters.RoleClaimType = "role";
+        options.TokenValidationParameters.RoleClaimType = Constants.Claims.Role;
     });
 
 builder.Logging.AddConsole();

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,5 +1,5 @@
 using AutoMapper;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -28,8 +28,8 @@ IdentitySetup();
 builder.Services.AddAuthentication()
     .AddJwtBearer(options =>
     {
-        options.Authority = "https://localhost:7047";
-        options.TokenValidationParameters.ValidateAudience = false;
+        options.Authority = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
+        options.Audience = "Timinute.ServerAPI";
     });
 
 builder.Logging.AddConsole();
@@ -158,32 +158,37 @@ void IdentitySetup()
         options.ClaimsIdentity.RoleClaimType = ClaimTypes.Role;
     });
 
+    var baseUrl = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
+
     builder.Services.AddIdentityServer(options =>
     {
-        options.IssuerUri = "https://localhost:7047";
+        options.IssuerUri = baseUrl;
     })
         .AddAspNetIdentity<ApplicationUser>()
-        .AddInMemoryIdentityResources(new List<Duende.IdentityServer.Models.IdentityResource>
+        .AddInMemoryIdentityResources(new List<IdentityResource>
         {
-            new Duende.IdentityServer.Models.IdentityResources.OpenId(),
-            new Duende.IdentityServer.Models.IdentityResources.Profile(),
+            new IdentityResources.OpenId
+            {
+                UserClaims = { "sub", Constants.Claims.Fullname, Constants.Claims.LastLogin, Constants.Claims.Role }
+            },
+            new IdentityResources.Profile(),
         })
-        .AddInMemoryApiScopes(new List<Duende.IdentityServer.Models.ApiScope>
+        .AddInMemoryApiScopes(new List<ApiScope>
         {
-            new Duende.IdentityServer.Models.ApiScope("Timinute.ServerAPI", "Timinute Server API")
+            new ApiScope("Timinute.ServerAPI", "Timinute Server API")
         })
-        .AddInMemoryClients(new List<Duende.IdentityServer.Models.Client>
+        .AddInMemoryClients(new List<Client>
         {
-            new Duende.IdentityServer.Models.Client
+            new Client
             {
                 ClientId = "Timinute.Client",
-                AllowedGrantTypes = Duende.IdentityServer.Models.GrantTypes.Code,
+                AllowedGrantTypes = GrantTypes.Code,
                 RequirePkce = true,
                 RequireClientSecret = false,
-                AllowedCorsOrigins = { "https://localhost:7047" },
+                AllowedCorsOrigins = { baseUrl },
                 AllowedScopes = { "openid", "profile", "Timinute.ServerAPI" },
-                RedirectUris = { "https://localhost:7047/authentication/login-callback" },
-                PostLogoutRedirectUris = { "https://localhost:7047/authentication/logout-callback" },
+                RedirectUris = { $"{baseUrl}/authentication/login-callback" },
+                PostLogoutRedirectUris = { $"{baseUrl}/authentication/logout-callback" },
             }
         });
 }

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,4 +1,5 @@
 using Duende.IdentityServer.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -24,7 +25,11 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 // Identity configuration
 IdentitySetup();
 
-builder.Services.AddAuthentication()
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
     .AddJwtBearer(options =>
     {
         options.Authority = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
@@ -159,7 +164,7 @@ void IdentitySetup()
 
     var baseUrl = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
 
-    builder.Services.AddIdentityServer(options =>
+    var identityServerBuilder = builder.Services.AddIdentityServer(options =>
     {
         options.IssuerUri = baseUrl;
     })
@@ -190,6 +195,11 @@ void IdentitySetup()
                 PostLogoutRedirectUris = { $"{baseUrl}/authentication/logout-callback" },
             }
         });
+
+    if (builder.Environment.IsDevelopment())
+    {
+        identityServerBuilder.AddDeveloperSigningCredential();
+    }
 }
 
 void DependecyInjection()

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddAuthentication(options =>
         options.ForwardDefaultSelector = context =>
         {
             string? authorization = context.Request.Headers.Authorization;
-            if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Bearer "))
+            if (!string.IsNullOrWhiteSpace(authorization) && authorization.TrimStart().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
                 return JwtBearerDefaults.AuthenticationScheme;
 
             return IdentityConstants.ApplicationScheme;
@@ -175,7 +175,9 @@ void IdentitySetup()
         options.ClaimsIdentity.RoleClaimType = Constants.Claims.Role;
     });
 
-    var baseUrl = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
+    var configuredUrl = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
+    var authorityUri = new Uri(configuredUrl);
+    var baseUrl = authorityUri.GetLeftPart(UriPartial.Authority);
 
     var identityServerBuilder = builder.Services.AddIdentityServer(options =>
     {

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -134,6 +134,7 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseIdentityServer();
+app.UseAuthentication();
 app.UseAuthorization();
 
 

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -34,6 +34,9 @@ builder.Services.AddAuthentication(options =>
     {
         options.Authority = builder.Configuration["IdentityServer:Authority"] ?? "https://localhost:7047";
         options.Audience = "Timinute.ServerAPI";
+        options.MapInboundClaims = false;
+        options.TokenValidationParameters.NameClaimType = "name";
+        options.TokenValidationParameters.RoleClaimType = "role";
     });
 
 builder.Logging.AddConsole();

--- a/Timinute/Server/Timinute.Server.csproj
+++ b/Timinute/Server/Timinute.Server.csproj
@@ -24,7 +24,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
+    <PackageReference Include="Duende.IdentityServer" Version="7.2.*" />
+    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.2.*" />
+    <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
       <PrivateAssets>all</PrivateAssets>

--- a/Timinute/Server/Timinute.Server.csproj
+++ b/Timinute/Server/Timinute.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>Timinute.Server-75E0B7C6-B48E-4FD7-BBCA-A6CC5498D4BE</UserSecretsId>

--- a/Timinute/Server/Timinute.Server.csproj
+++ b/Timinute/Server/Timinute.Server.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
     <PackageReference Include="Duende.IdentityServer" Version="7.2.*" />
     <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.2.*" />
-    <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
       <PrivateAssets>all</PrivateAssets>

--- a/Timinute/Server/Timinute.Server.csproj
+++ b/Timinute/Server/Timinute.Server.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.7" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,14 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
-    <PackageReference Include="Duende.IdentityServer" Version="7.2.*" />
-    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.2.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
+    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Timinute/Server/appsettings.json
+++ b/Timinute/Server/appsettings.json
@@ -9,11 +9,7 @@
     }
   },
   "IdentityServer": {
-    "Clients": {
-      "Timinute.Client": {
-        "Profile": "IdentityServerSPA"
-      }
-    }
+    "Authority": "https://localhost:7047"
   },
   "AllowedHosts": "*"
 }

--- a/Timinute/Shared/Timinute.Shared.csproj
+++ b/Timinute/Shared/Timinute.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/docs/superpowers/plans/2026-03-31-timinute-modernization.md
+++ b/docs/superpowers/plans/2026-03-31-timinute-modernization.md
@@ -1,0 +1,588 @@
+# Timinute Modernization Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade Timinute from .NET 8 to .NET 10, update all packages, verify functionality, expand test coverage, redesign UI, and plan new features.
+
+**Architecture:** Blazor WebAssembly hosted app (Server + Client + Shared). Repository pattern with generic factory. IdentityServer for auth. Radzen component library for UI. xUnit + Moq + EF InMemory for tests.
+
+**Tech Stack:** .NET 10, Blazor WASM, EF Core, SQL Server, Radzen.Blazor, Duende IdentityServer, xUnit, Moq
+
+---
+
+## Phase 1: Upgrade to .NET 10
+
+> Branch: `feature/upgrade_to_net_10` off `develop`
+
+The existing `feature/upgrade_project_to_net_9` branch has useful reference (Duende IdentityServer migration, async test fixes) but we'll do a clean upgrade from `develop` directly to .NET 10.
+
+### Task 1.1: Upgrade Target Frameworks
+
+**Files:**
+- Modify: `Timinute/Shared/Timinute.Shared.csproj`
+- Modify: `Timinute/Server/Timinute.Server.csproj`
+- Modify: `Timinute/Client/Timinute.Client.csproj`
+- Modify: `Timinute/Server.Tests/Timinute.Server.Tests.csproj`
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout develop
+git checkout -b feature/upgrade_to_net_10
+```
+
+- [ ] **Step 2: Update Shared project TFM**
+
+In `Timinute/Shared/Timinute.Shared.csproj`, change:
+```xml
+<TargetFramework>net8.0</TargetFramework>
+```
+to:
+```xml
+<TargetFramework>net10.0</TargetFramework>
+```
+
+- [ ] **Step 3: Update Server project TFM**
+
+In `Timinute/Server/Timinute.Server.csproj`, change:
+```xml
+<TargetFramework>net8.0</TargetFramework>
+```
+to:
+```xml
+<TargetFramework>net10.0</TargetFramework>
+```
+
+- [ ] **Step 4: Update Client project TFM**
+
+In `Timinute/Client/Timinute.Client.csproj`, change:
+```xml
+<TargetFramework>net8.0</TargetFramework>
+```
+to:
+```xml
+<TargetFramework>net10.0</TargetFramework>
+```
+
+- [ ] **Step 5: Update Test project TFM**
+
+In `Timinute/Server.Tests/Timinute.Server.Tests.csproj`, change:
+```xml
+<TargetFramework>net8.0</TargetFramework>
+```
+to:
+```xml
+<TargetFramework>net10.0</TargetFramework>
+```
+
+- [ ] **Step 6: Verify solution builds**
+
+```bash
+dotnet build Timinute.sln
+```
+Expected: Build errors related to outdated package versions (will fix in Task 1.2).
+
+- [ ] **Step 7: Commit TFM changes**
+
+```bash
+git add Timinute/Shared/Timinute.Shared.csproj Timinute/Server/Timinute.Server.csproj Timinute/Client/Timinute.Client.csproj Timinute/Server.Tests/Timinute.Server.Tests.csproj
+git commit -m "chore: update target framework to .NET 10"
+```
+
+### Task 1.2: Replace IdentityServer4 with Duende IdentityServer
+
+`Microsoft.AspNetCore.ApiAuthorization.IdentityServer` is removed in .NET 10. Must migrate to Duende IdentityServer.
+
+**Files:**
+- Modify: `Timinute/Server/Timinute.Server.csproj`
+- Modify: `Timinute/Server/Program.cs`
+- Modify: `Timinute/Server/Data/ApplicationDbContext.cs`
+- Modify: `Timinute/Server.Tests/Timinute.Server.Tests.csproj`
+- Modify: `Timinute/Server.Tests/Helpers/ControllerTestBase.cs`
+
+- [ ] **Step 1: Update Server.csproj packages**
+
+Remove the old IdentityServer package reference:
+```xml
+<PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.20" />
+```
+
+Add Duende packages:
+```xml
+<PackageReference Include="Duende.IdentityServer" Version="7.2.*" />
+<PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.2.*" />
+<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.*" />
+```
+
+- [ ] **Step 2: Update Server Program.cs**
+
+Replace `AddApiAuthorization` with Duende IdentityServer configuration. Replace:
+```csharp
+using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
+```
+with:
+```csharp
+using Duende.IdentityServer;
+using Duende.IdentityServer.Models;
+```
+
+Update the IdentityServer registration in Program.cs to use Duende's API:
+```csharp
+builder.Services.AddIdentityServer()
+    .AddApiAuthorization<ApplicationUser, ApplicationDbContext>();
+```
+
+- [ ] **Step 3: Update ApplicationDbContext**
+
+Change base class from `ApiAuthorizationDbContext` to Duende's equivalent. Update using statements accordingly.
+
+- [ ] **Step 4: Update Test project packages**
+
+Add Duende packages to `Server.Tests.csproj` and update `ControllerTestBase.cs` to use Duende's operational store options.
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+dotnet build Timinute.sln
+```
+Expected: Successful build.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+dotnet test
+```
+Expected: All existing tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "chore: migrate from IdentityServer4 to Duende IdentityServer"
+```
+
+---
+
+## Phase 2: Update All NuGet Packages
+
+### Task 2.1: Update Server Packages
+
+**Files:**
+- Modify: `Timinute/Server/Timinute.Server.csproj`
+
+- [ ] **Step 1: Check latest package versions**
+
+```bash
+cd Timinute/Server && dotnet list package --outdated
+```
+
+- [ ] **Step 2: Update all packages to latest stable**
+
+Update each `<PackageReference>` to the latest stable version. Key packages to update:
+- `Microsoft.AspNetCore.Components.WebAssembly.Server` → 10.0.*
+- `Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore` → 10.0.*
+- `Microsoft.AspNetCore.Identity.EntityFrameworkCore` → 10.0.*
+- `Microsoft.AspNetCore.Identity.UI` → 10.0.*
+- `Microsoft.EntityFrameworkCore.SqlServer` → 10.0.*
+- `Microsoft.EntityFrameworkCore.Tools` → 10.0.*
+- `Microsoft.VisualStudio.Web.CodeGeneration.Design` → latest
+- `AutoMapper` → latest stable
+- `Swashbuckle.AspNetCore` → latest stable
+- `System.Linq.Dynamic.Core` → latest stable
+
+- [ ] **Step 3: Build server project**
+
+```bash
+dotnet build Timinute/Server/Timinute.Server.csproj
+```
+Expected: Successful build. Fix any breaking API changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Server/Timinute.Server.csproj
+git commit -m "chore: update server NuGet packages"
+```
+
+### Task 2.2: Update Client Packages
+
+**Files:**
+- Modify: `Timinute/Client/Timinute.Client.csproj`
+
+- [ ] **Step 1: Check latest package versions**
+
+```bash
+cd Timinute/Client && dotnet list package --outdated
+```
+
+- [ ] **Step 2: Update all packages**
+
+Key packages:
+- `Microsoft.AspNetCore.Components.WebAssembly` → 10.0.*
+- `Microsoft.AspNetCore.Components.WebAssembly.DevServer` → 10.0.*
+- `Microsoft.AspNetCore.Components.WebAssembly.Authentication` → 10.0.*
+- `Microsoft.Extensions.Http` → 10.0.*
+- `Radzen.Blazor` → latest stable (major version upgrade — check breaking changes)
+- `Blazored.SessionStorage` → latest stable
+- `System.Linq.Dynamic.Core` → latest stable
+
+- [ ] **Step 3: Fix Radzen breaking changes**
+
+Radzen 5.x → 6.x+ has breaking changes. Check all Razor files using Radzen components:
+- `Components/Dashboard/DoughnutChart.razor`
+- `Components/Dashboard/ProjectColumnChart.razor`
+- `Components/TrackedTasks/TrackedTaskTable.razor` (RadzenPager)
+- Any forms using Radzen input components
+
+- [ ] **Step 4: Build client project**
+
+```bash
+dotnet build Timinute/Client/Timinute.Client.csproj
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Client/Timinute.Client.csproj
+git commit -m "chore: update client NuGet packages"
+```
+
+### Task 2.3: Update Test Packages
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Timinute.Server.Tests.csproj`
+
+- [ ] **Step 1: Update test packages**
+
+Key packages:
+- `Microsoft.NET.Test.Sdk` → latest
+- `xunit` → latest stable
+- `xunit.runner.visualstudio` → latest stable
+- `Moq` → latest stable
+- `Microsoft.EntityFrameworkCore.InMemory` → 10.0.*
+- `coverlet.collector` → latest stable
+
+- [ ] **Step 2: Fix async test signatures**
+
+Change `async void` to `async Task` in:
+- `Repositories/ProjectRepositoryTest.cs` (lines 39, 54, 69)
+- `Repositories/TrackedTaskRepositoryTest.cs` (lines 44, 58, 72, 86)
+
+- [ ] **Step 3: Run tests**
+
+```bash
+dotnet test
+```
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Server.Tests/Timinute.Server.Tests.csproj Timinute/Server.Tests/Repositories/
+git commit -m "chore: update test NuGet packages and fix async signatures"
+```
+
+---
+
+## Phase 3: Verify Functionality
+
+### Task 3.1: Build and Test Verification
+
+- [ ] **Step 1: Clean build**
+
+```bash
+dotnet clean Timinute.sln && dotnet build Timinute.sln
+```
+Expected: 0 errors, 0 warnings (or known warnings only).
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+dotnet test --verbosity normal
+```
+Expected: All tests pass.
+
+- [ ] **Step 3: Check for runtime issues**
+
+```bash
+dotnet run --project Timinute/Server/Timinute.Server.csproj
+```
+Manually verify:
+- App starts on https://localhost:7047
+- Login page renders
+- Swagger UI at /swagger loads
+- No console errors
+
+- [ ] **Step 4: Verify database connectivity**
+
+Ensure Docker SQL Server is running, then verify EF migrations apply:
+```bash
+dotnet ef database update --project Timinute/Server/Timinute.Server.csproj
+```
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve .NET 10 upgrade compatibility issues"
+```
+
+---
+
+## Phase 4: Extend Unit Test Coverage
+
+> Branch: continue on `feature/upgrade_to_net_10` or create `feature/test_coverage` off it
+
+### Task 4.1: Add Repository Delete Tests
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Repositories/ProjectRepositoryTest.cs`
+- Modify: `Timinute/Server.Tests/Repositories/TrackedTaskRepositoryTest.cs`
+
+- [ ] **Step 1: Write failing delete test for ProjectRepository**
+
+```csharp
+[Fact]
+public async Task Delete_Existing_Project_Test()
+{
+    var project = await _repository.Find("ProjectId1");
+    Assert.NotNull(project);
+
+    await _repository.Delete(project);
+
+    var deleted = await _repository.Find("ProjectId1");
+    Assert.Null(deleted);
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ProjectRepositoryTest.Delete_Existing_Project_Test"
+```
+
+- [ ] **Step 3: Write delete-by-id test**
+
+```csharp
+[Fact]
+public async Task Delete_Project_By_Id_Test()
+{
+    await _repository.Delete("ProjectId1");
+
+    var deleted = await _repository.Find("ProjectId1");
+    Assert.Null(deleted);
+}
+```
+
+- [ ] **Step 4: Write delete tests for TrackedTaskRepository**
+
+Same pattern as above for TrackedTask entities.
+
+- [ ] **Step 5: Run all repository tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~RepositoryTest"
+```
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server.Tests/Repositories/
+git commit -m "test: add repository delete tests"
+```
+
+### Task 4.2: Add Missing Analytics Controller Tests
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs`
+
+- [ ] **Step 1: Add test for GetWorkTimePerMonths endpoint**
+
+This endpoint (AnalyticsController line 127) has no test coverage. Write a test that:
+- Seeds tracked tasks across multiple months
+- Calls GetWorkTimePerMonths
+- Asserts correct monthly aggregation and "yyyy MMM" format
+
+- [ ] **Step 2: Add test for empty data scenario**
+
+Test analytics endpoints when user has no tracked tasks — should return empty collections, not errors.
+
+- [ ] **Step 3: Run analytics tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~AnalyticsControllerTest"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Server.Tests/Controllers/AnalyticsControllerTest.cs
+git commit -m "test: add missing analytics controller tests"
+```
+
+### Task 4.3: Add Input Validation Tests
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs`
+- Modify: `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs`
+
+- [ ] **Step 1: Add null/empty input tests for ProjectController**
+
+Test CreateProject with null name, UpdateProject with empty ID, etc.
+
+- [ ] **Step 2: Add date/duration validation tests for TrackedTaskController**
+
+Test CreateTrackedTask with:
+- Zero duration
+- Negative duration
+- Future start dates (if disallowed)
+- Missing project ID
+
+- [ ] **Step 3: Run all controller tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ControllerTest"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Server.Tests/Controllers/
+git commit -m "test: add input validation tests for controllers"
+```
+
+### Task 4.4: Add Authorization Edge Case Tests
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs`
+- Modify: `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs`
+
+- [ ] **Step 1: Test accessing another user's resources**
+
+Verify that User1 cannot update/delete User2's projects or tasks. ProjectController already has `Update_Project_Another_User_Test` — add equivalent for:
+- Delete another user's project
+- Update another user's tracked task
+- Delete another user's tracked task
+
+- [ ] **Step 2: Run tests**
+
+```bash
+dotnet test
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Timinute/Server.Tests/Controllers/
+git commit -m "test: add cross-user authorization tests"
+```
+
+---
+
+## Phase 5: UI and Visual Redesign (Planning)
+
+> This phase produces a design document, not code. Implementation will be a separate plan.
+
+### Task 5.1: Audit Current UI
+
+- [ ] **Step 1: Document current pages and layout**
+
+Review and document:
+- `Client/Shared/MainLayout.razor` — current layout structure
+- `Client/Shared/NavMenu.razor` — navigation items
+- `Client/Pages/` — all page routes and their purpose
+- `Client/Components/` — all reusable components
+- `Client/wwwroot/css/` — current styling approach
+
+- [ ] **Step 2: Identify UI pain points**
+
+List current limitations:
+- Mobile responsiveness
+- Theme/dark mode support
+- Component consistency
+- Navigation UX
+- Dashboard information density
+- Form design patterns
+
+- [ ] **Step 3: Write UI redesign spec**
+
+Create `docs/superpowers/plans/ui-redesign-spec.md` with:
+- Current state screenshots/descriptions
+- Proposed layout changes
+- Component library upgrade plan (Radzen 6.x+ features)
+- Color scheme / theming approach
+- Mobile-first responsive design goals
+- Accessibility improvements
+
+- [ ] **Step 4: Commit spec**
+
+```bash
+git add docs/superpowers/plans/ui-redesign-spec.md
+git commit -m "docs: add UI redesign specification"
+```
+
+---
+
+## Phase 6: Feature Extension Planning
+
+> This phase produces a feature roadmap document. Implementation will be separate plans per feature.
+
+### Task 6.1: Audit Existing Features
+
+- [ ] **Step 1: Map current feature set**
+
+Document what currently exists:
+- Project CRUD (create, list, edit, delete)
+- Tracked task CRUD with timer
+- Task scheduler/calendar view
+- Dashboard with analytics (doughnut chart, column chart)
+- Monthly work time analytics
+- Per-project work time breakdown
+- User authentication and authorization
+
+- [ ] **Step 2: Identify gaps and improvement areas**
+
+Review controllers, UI, and user flows for:
+- Missing CRUD operations or incomplete flows
+- Data export capabilities
+- Reporting depth
+- Multi-user / team features
+- Notification system
+- Search and filtering
+- Settings/preferences
+
+- [ ] **Step 3: Write feature roadmap**
+
+Create `docs/superpowers/plans/feature-roadmap.md` with prioritized feature list:
+- **P0 (Must-have):** Bug fixes, incomplete features, data integrity
+- **P1 (Should-have):** User-requested improvements, productivity features
+- **P2 (Nice-to-have):** Advanced analytics, integrations, team features
+
+Each feature entry should include:
+- Description
+- User value
+- Estimated complexity (S/M/L)
+- Dependencies on other features
+
+- [ ] **Step 4: Commit roadmap**
+
+```bash
+git add docs/superpowers/plans/feature-roadmap.md
+git commit -m "docs: add feature extension roadmap"
+```
+
+---
+
+## Execution Order
+
+Phases 1-3 are sequential (upgrade → packages → verify). Phase 4 can start after Phase 3 passes. Phases 5 and 6 are independent research tasks that can run in parallel with Phase 4.
+
+```
+Phase 1 (TFM + IdentityServer) → Phase 2 (Packages) → Phase 3 (Verify)
+                                                              ↓
+                                                    ┌─────────┼─────────┐
+                                                    ↓         ↓         ↓
+                                                Phase 4    Phase 5   Phase 6
+                                                (Tests)    (UI Spec) (Features)
+```

--- a/docs/superpowers/plans/feature-roadmap.md
+++ b/docs/superpowers/plans/feature-roadmap.md
@@ -1,0 +1,73 @@
+# Timinute Feature Roadmap
+
+## Current Feature Set
+
+- **Auth:** Registration, JWT auth via Duende IdentityServer, roles (Basic/Admin), lockout
+- **Projects:** Full CRUD, user-scoped, pagination
+- **Task Tracking:** Full CRUD, real-time stopwatch timer, session storage persistence, manual entry
+- **Calendar:** Scheduler view (Day/Week/Month) with add/edit forms
+- **Analytics:** Project work time, monthly aggregation, top project stats, donut + column charts
+- **Data Access:** Generic repository pattern with paging, filtering, dynamic LINQ ordering
+
+## P0: Must-Have (Security & Data Integrity)
+
+| Feature | Description | Complexity |
+|---------|-------------|------------|
+| Data validation | Add Required/MaxLength/Range attributes to DTOs, validate EndDate > StartDate, duration > 0 | S |
+| Analytics optimization | Replace LINQ-to-Objects with DB-side queries (Dapper or raw SQL) for analytics endpoints | M |
+| Timer edge cases | Handle overlapping tasks, impossible durations, better session persistence | S |
+| Soft delete | Add IsArchived flag to tasks/projects instead of hard delete, with recovery | M |
+
+## P1: Should-Have (Productivity & UX)
+
+| Feature | Description | Complexity | Dependencies |
+|---------|-------------|------------|--------------|
+| Data export | CSV/PDF export for tracked tasks and analytics | M | None |
+| Advanced filtering | Date range API filters, full-text search on task names, filter persistence | M | None |
+| Tags/Labels | Tag model with many-to-many Tag-Task relationship, UI for tagging | M | None |
+| Enhanced analytics | Custom date ranges, daily/weekly summaries, productivity trends | M | Analytics optimization |
+| Settings/Preferences | User profile page, timezone config, workday hours, dark mode preference | M | None |
+| Notifications | Idle time warnings, task reminders via SignalR or browser push | M | None |
+| Time tracking enhancements | Pomodoro timer, time estimates/goals, break tracking | L | None |
+
+## P2: Nice-to-Have (Advanced & Team)
+
+| Feature | Description | Complexity | Dependencies |
+|---------|-------------|------------|--------------|
+| Team workspaces | Project sharing, team dashboards, task assignment | L | Settings |
+| Calendar integration | Google Calendar / Outlook sync | L | None |
+| Jira/GitHub integration | Link tasks to external tickets | L | Tags |
+| Audit logging | Track all changes for compliance | M | None |
+| Reporting suite | Scheduled email reports, custom report builder | L | Data export |
+| AI categorization | Automatic task categorization and productivity recommendations | L | Tags |
+
+## Dependency Graph
+
+```
+P0 (Security/Integrity) ── foundation for everything
+│
+├─ P1 (UX)
+│  ├─ Advanced Filtering (independent)
+│  ├─ Data Export (independent)
+│  ├─ Tags/Labels (independent)
+│  ├─ Settings (independent)
+│  ├─ Enhanced Analytics ← depends on Analytics optimization
+│  ├─ Notifications (independent)
+│  └─ Time Tracking Enhancements (independent)
+│
+└─ P2 (Advanced)
+   ├─ Team Workspaces ← depends on Settings
+   ├─ Integrations ← benefits from Tags
+   ├─ Reporting ← depends on Data Export
+   └─ AI Features ← depends on Tags
+```
+
+## Technical Debt to Address
+
+- Constants class growing large — split per domain
+- Add request/response logging middleware
+- Add DB indexes on UserId, ProjectId for query performance
+- Add composite indexes for common analytics queries
+- Add unique constraint: project names per user
+- API versioning for future breaking changes
+- Extract common DataGrid logic into reusable component

--- a/docs/superpowers/plans/ui-redesign-spec.md
+++ b/docs/superpowers/plans/ui-redesign-spec.md
@@ -1,0 +1,96 @@
+# Timinute UI Redesign Specification
+
+## Current State Summary
+
+- Blazor WASM with Radzen 10.x + Bootstrap 5
+- Flexbox sidebar layout, single breakpoint at 640px
+- Material theme, no dark mode
+- Mixed form patterns (Bootstrap EditForm + Radzen TemplateForm)
+- Open Iconic icons (limited set)
+- Dashboard: 2x2 stat cards + column chart + donut chart
+
+## Key Pain Points
+
+1. **Inconsistent components** — Bootstrap EditForm in some places, Radzen in others
+2. **Single responsive breakpoint** — misses tablet and large desktop
+3. **No dark mode** or theme customization
+4. **Limited mobile experience** — calendar height exceeds viewport, tables don't adapt
+5. **Dashboard lacks depth** — no trends, no goals, no interactivity
+6. **Accessibility gaps** — limited ARIA labels, no skip-to-content, inconsistent focus states
+7. **Dated navigation** — no breadcrumbs, no collapsible panel menu, basic category headers
+
+## Proposed Architecture
+
+### Layout
+```
+Desktop (>=992px): Collapsible sidebar (240px/64px) + top bar (56px) + main content
+Tablet (768-991px): Hidden sidebar + top bar with hamburger + main content
+Mobile (<768px): Top bar + main content + optional bottom nav
+```
+
+### Theme System
+- CSS custom properties for colors, spacing, typography, shadows
+- `[data-theme="dark"]` selector for dark mode overrides
+- Theme toggle in top bar, persisted to localStorage
+- Material Design color palette (Blue primary, neutral grays)
+
+### Navigation Redesign
+- **RadzenPanelMenu** for collapsible sidebar sections
+- **RadzenBreadcrumb** for page context
+- **RadzenProfileMenu** for user dropdown (profile, settings, logout)
+- Active state: left accent bar + highlighted background
+- Touch targets: 44x44px minimum
+
+### Form Standardization
+- All forms use **RadzenTemplateForm** + **RadzenFormField** (Variant.Outlined)
+- Consistent spacing via CSS variables
+- Inline validation with **RadzenRequiredValidator**
+- Full-width on mobile, max-width 600px container on desktop
+- Submit + Cancel button pattern
+
+### Dashboard Redesign
+- Quick stats row: Total hours, avg/day, top project, streak
+- Trend indicators (up/down arrows with percentage)
+- Active projects table with click-to-drill-down
+- Recent activity timeline (last 5 tasks)
+- Interactive charts with tooltips
+- Date range picker for custom periods
+
+### Data Grid Enhancements
+- Responsive column hiding on mobile
+- **RadzenSplitButton** for row actions (Edit/Delete/Duplicate)
+- Loading skeletons via **RadzenSkeleton**
+- Meaningful empty states with CTA buttons
+- Checkbox selection for bulk operations
+
+### Radzen 10.x Components to Adopt
+- RadzenSideBar, RadzenCard, RadzenSplitButton, RadzenPanelMenu
+- RadzenFormField, RadzenProfileMenu, RadzenBreadcrumb
+- RadzenSkeleton, RadzenBadge, RadzenTabs
+- RadzenContextMenu, RadzenProgressBar
+
+## Responsive Breakpoints
+- xs: <576px (mobile portrait)
+- sm: >=576px (mobile landscape)
+- md: >=768px (tablet)
+- lg: >=992px (desktop)
+- xl: >=1200px (large desktop)
+- xxl: >=1400px (extra large)
+
+## Accessibility Goals (WCAG AA)
+- Color contrast >=4.5:1 for normal text, >=3:1 for large text
+- All interactive elements keyboard-focusable with visible indicators
+- Semantic HTML (nav, main, article, button)
+- ARIA labels on icon-only buttons
+- Skip-to-content link
+- prefers-reduced-motion support
+
+## Implementation Phases
+
+1. **Foundation** — CSS variables, theme toggle, layout refactor
+2. **Navigation** — RadzenPanelMenu, breadcrumbs, profile menu
+3. **Forms** — Standardize all forms to RadzenFormField pattern
+4. **Dashboard** — Metric cards, trends, interactive charts
+5. **Data Tables** — Responsive columns, split buttons, empty states
+6. **Accessibility** — ARIA audit, keyboard nav, screen reader testing
+7. **Polish** — Cross-browser testing, performance, user feedback

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

- Upgrade all projects from .NET 8 to .NET 10
- Migrate from deprecated `Microsoft.AspNetCore.ApiAuthorization.IdentityServer` to Duende IdentityServer 7.4
- Update all NuGet packages to latest stable versions (AutoMapper 16, Radzen 10, EF Core 10, Swashbuckle 9)
- Fix pre-existing failing analytics test (timezone date boundary bug)
- Expand test coverage from 39/40 to 47/47 (delete tests, analytics gaps, cross-user authorization)
- Add planning documents for UI redesign and feature roadmap

## Changes

**IdentityServer Migration:**
- Replaced `ApiAuthorizationDbContext` with `IdentityDbContext`
- Configured Duende with in-memory resources, scopes, and clients
- Custom claims (Fullname, LastLogin, Role) registered on OpenId identity resource
- Authority URL configurable via `appsettings.json`
- Proper JWT audience validation enabled
- Removed `OidcConfigurationController` (Duende exposes `/.well-known/openid-configuration`)
- Client switched from `AddApiAuthorization()` to `AddOidcAuthentication()`
- Service worker updated to remove broken `_configuration` endpoint

**Package Updates:**
- All Microsoft packages → 10.0.5
- AutoMapper 13.0.1 → 16.1.1 (security fix + API migration)
- Radzen.Blazor 5.4.0 → 10.1.0
- Duende.IdentityServer → 7.4.7
- System.Linq.Dynamic.Core 1.4.7 → 1.7.1 (security fix)

**Test Improvements:**
- Fixed `Get_Amount_Work_Time_Last_Month_Test` timezone bug in seed data
- Added repository delete tests (Project + TrackedTask)
- Added `GetWorkTimePerMonths` analytics endpoint test
- Added cross-user authorization tests (delete project, update task)
- Fixed `async void` → `async Task` in repository tests

## Test plan

- [x] `dotnet build Timinute.sln` — 0 errors
- [x] `dotnet test` — 47/47 passing
- [ ] Manual smoke test: app starts, login page renders, Swagger loads
- [ ] Verify Duende discovery endpoint at `/.well-known/openid-configuration`