### PR TITLE
Add CSV and Excel data export endpoints

### DIFF
--- a/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
@@ -98,6 +98,55 @@ namespace Timinute.Server.Tests.Controllers
             Assert.Single(lines); // header only, no data
         }
 
+        [Fact]
+        public async Task Export_Projects_Csv_Returns_File_With_Grouped_Data()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportProjects("csv", null, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("text/csv", fileResult!.ContentType);
+            Assert.Contains("projects-export-", fileResult.FileDownloadName);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            // ApplicationUser1 has tasks in ProjectId1 + some without project
+            Assert.True(lines.Length >= 2); // header + at least 1 project row
+            Assert.Contains("ProjectName", lines[0]);
+            Assert.Contains("TotalHours", lines[0]);
+            Assert.Contains("TaskCount", lines[0]);
+        }
+
+        [Fact]
+        public async Task Export_Analytics_Csv_Returns_File_With_Monthly_Data()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportAnalytics("csv", null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("text/csv", fileResult!.ContentType);
+            Assert.Contains("analytics-export-", fileResult.FileDownloadName);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.True(lines.Length >= 2); // header + at least 1 month
+            Assert.Contains("Month", lines[0]);
+            Assert.Contains("TotalHours", lines[0]);
+            Assert.Contains("TopProject", lines[0]);
+        }
+
         protected override async Task<ExportController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
         {
             if (applicationDbContext == null)

--- a/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
@@ -1,0 +1,126 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Timinute.Server.Controllers;
+using Timinute.Server.Data;
+using Timinute.Server.Repository;
+using Timinute.Server.Services;
+using Timinute.Server.Tests.Helpers;
+using Xunit;
+
+namespace Timinute.Server.Tests.Controllers
+{
+    public class ExportControllerTest : ControllerTestBase<ExportController>
+    {
+        private readonly Mock<ILogger<ExportController>> _loggerMock;
+        private readonly IExportService _exportService;
+
+        private const string _databaseName = "ExportController_Test_DB";
+
+        public ExportControllerTest()
+        {
+            _loggerMock = new Mock<ILogger<ExportController>>();
+            _exportService = new ExportService();
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Csv_Returns_File()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportTasks("csv", null, null, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("text/csv", fileResult!.ContentType);
+            Assert.Contains("tracked-tasks-export-", fileResult.FileDownloadName);
+            Assert.EndsWith(".csv", fileResult.FileDownloadName);
+            Assert.True(fileResult.FileContents.Length > 0);
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Xlsx_Returns_File()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportTasks("xlsx", null, null, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileResult!.ContentType);
+            Assert.EndsWith(".xlsx", fileResult.FileDownloadName);
+        }
+
+        [Fact]
+        public async Task Export_Tasks_With_DateRange_Filters()
+        {
+            ExportController controller = await CreateController();
+
+            var from = new System.DateTime(2021, 10, 1);
+            var to = new System.DateTime(2021, 10, 31);
+
+            var actionResult = await controller.ExportTasks("csv", from, to, null, null);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult!.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            // ApplicationUser1 has 4 tasks, all on 2021-10-01
+            Assert.Equal(5, lines.Length); // header + 4 data rows
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Another_User_Returns_Empty_File()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "AuthTest");
+            ExportController controller = await CreateController(applicationDbContext, "NonExistentUser");
+
+            var actionResult = await controller.ExportTasks("csv", null, null, null, null);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult!.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Single(lines); // header only, no data
+        }
+
+        protected override async Task<ExportController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
+        {
+            if (applicationDbContext == null)
+            {
+                applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName);
+            }
+
+            var repositoryFactory = new RepositoryFactory(applicationDbContext);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {
+                new Claim("sub", userId),
+                new Claim(ClaimTypes.Name, "test1@email.com")
+            }));
+
+            ExportController controller = new(repositoryFactory, _exportService, _loggerMock.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = user }
+                }
+            };
+
+            return controller;
+        }
+    }
+}

--- a/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ExportControllerTest.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/Timinute/Server.Tests/Services/ExportServiceTest.cs
+++ b/Timinute/Server.Tests/Services/ExportServiceTest.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Timinute.Server.Models.Export;
+using Timinute.Server.Services;
+using Xunit;
+
+namespace Timinute.Server.Tests.Services
+{
+    public class ExportServiceTest
+    {
+        private readonly ExportService _exportService;
+
+        public ExportServiceTest()
+        {
+            _exportService = new ExportService();
+        }
+
+        [Fact]
+        public void ToCsv_Returns_Valid_Csv_With_Headers_And_Rows()
+        {
+            var data = new List<TaskExportDto>
+            {
+                new TaskExportDto { Name = "Task 1", ProjectName = "Project A", StartDate = "2026-04-01 09:00", EndDate = "2026-04-01 11:00", Duration = "02:00:00", Date = "2026-04-01" },
+                new TaskExportDto { Name = "Task 2", ProjectName = "Project B", StartDate = "2026-04-01 13:00", EndDate = "2026-04-01 15:00", Duration = "02:00:00", Date = "2026-04-01" },
+            };
+
+            var result = _exportService.ToCsv(data);
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
+
+            var csv = System.Text.Encoding.UTF8.GetString(result);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Equal(3, lines.Length);
+            Assert.Contains("Name", lines[0]);
+            Assert.Contains("ProjectName", lines[0]);
+            Assert.Contains("Task 1", lines[1]);
+            Assert.Contains("Task 2", lines[2]);
+        }
+
+        [Fact]
+        public void ToCsv_Empty_Data_Returns_Headers_Only()
+        {
+            var data = new List<TaskExportDto>();
+
+            var result = _exportService.ToCsv(data);
+
+            Assert.NotNull(result);
+            var csv = System.Text.Encoding.UTF8.GetString(result);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Single(lines);
+            Assert.Contains("Name", lines[0]);
+        }
+    }
+}

--- a/Timinute/Server.Tests/Services/ExportServiceTest.cs
+++ b/Timinute/Server.Tests/Services/ExportServiceTest.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ClosedXML.Excel;
 using Timinute.Server.Models.Export;
 using Timinute.Server.Services;
 using Xunit;
@@ -51,6 +54,46 @@ namespace Timinute.Server.Tests.Services
 
             Assert.Single(lines);
             Assert.Contains("Name", lines[0]);
+        }
+
+        [Fact]
+        public void ToExcel_Returns_Valid_Xlsx_With_Data()
+        {
+            var data = new List<TaskExportDto>
+            {
+                new TaskExportDto { Name = "Task 1", ProjectName = "Project A", StartDate = "2026-04-01 09:00", EndDate = "2026-04-01 11:00", Duration = "02:00:00", Date = "2026-04-01" },
+                new TaskExportDto { Name = "Task 2", ProjectName = "Project B", StartDate = "2026-04-01 13:00", EndDate = "2026-04-01 15:00", Duration = "02:00:00", Date = "2026-04-01" },
+            };
+
+            var result = _exportService.ToExcel(data, "Tasks");
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
+
+            using var stream = new MemoryStream(result);
+            using var workbook = new XLWorkbook(stream);
+
+            Assert.Single(workbook.Worksheets);
+            Assert.Equal("Tasks", workbook.Worksheets.First().Name);
+
+            var worksheet = workbook.Worksheets.First();
+            Assert.Equal(3, worksheet.RowsUsed().Count());
+        }
+
+        [Fact]
+        public void ToExcel_Empty_Data_Returns_Valid_Xlsx()
+        {
+            var data = new List<TaskExportDto>();
+
+            var result = _exportService.ToExcel(data, "Empty");
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
+
+            using var stream = new MemoryStream(result);
+            using var workbook = new XLWorkbook(stream);
+
+            Assert.Equal("Empty", workbook.Worksheets.First().Name);
         }
     }
 }

--- a/Timinute/Server.Tests/Timinute.Server.Tests.csproj
+++ b/Timinute/Server.Tests/Timinute.Server.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -1,0 +1,165 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Timinute.Server.Helpers;
+using Timinute.Server.Models;
+using Timinute.Server.Models.Export;
+using Timinute.Server.Repository;
+using Timinute.Server.Services;
+
+namespace Timinute.Server.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class ExportController : ControllerBase
+    {
+        private readonly IRepository<TrackedTask> taskRepository;
+        private readonly IRepository<Project> projectRepository;
+        private readonly IExportService exportService;
+        private readonly ILogger<ExportController> logger;
+
+        public ExportController(IRepositoryFactory repositoryFactory, IExportService exportService, ILogger<ExportController> logger)
+        {
+            this.exportService = exportService;
+            this.logger = logger;
+
+            taskRepository = repositoryFactory.GetRepository<TrackedTask>();
+            projectRepository = repositoryFactory.GetRepository<Project>();
+        }
+
+        [HttpGet("tasks")]
+        public async Task<ActionResult> ExportTasks(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null,
+            [FromQuery] string? projectId = null,
+            [FromQuery] string? search = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime())
+                    && (projectId == null || t.ProjectId == projectId)
+                    && (search == null || t.Name.Contains(search)),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks.Select(t => new TaskExportDto
+            {
+                Name = t.Name,
+                ProjectName = t.Project?.Name ?? "None",
+                StartDate = t.StartDate.ToString("yyyy-MM-dd HH:mm"),
+                EndDate = t.EndDate?.ToString("yyyy-MM-dd HH:mm") ?? "",
+                Duration = FormatDuration(t.Duration),
+                Date = t.StartDate.ToString("yyyy-MM-dd"),
+            }).ToList();
+
+            return GenerateFile(exportData, format, "tracked-tasks");
+        }
+
+        [HttpGet("projects")]
+        public async Task<ActionResult> ExportProjects(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null,
+            [FromQuery] string? search = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime()),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks
+                .GroupBy(t => t.ProjectId ?? "None")
+                .Select(g =>
+                {
+                    var projectName = g.First().Project?.Name ?? "None";
+                    if (!string.IsNullOrEmpty(search) && !projectName.Contains(search, StringComparison.OrdinalIgnoreCase))
+                        return null;
+
+                    return new ProjectExportDto
+                    {
+                        ProjectName = projectName,
+                        TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
+                        TaskCount = g.Count(),
+                    };
+                })
+                .Where(x => x != null)
+                .ToList();
+
+            return GenerateFile(exportData!, format, "projects");
+        }
+
+        [HttpGet("analytics")]
+        public async Task<ActionResult> ExportAnalytics(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime()),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks
+                .GroupBy(t => new { t.StartDate.Year, t.StartDate.Month })
+                .Select(g =>
+                {
+                    var topProject = g
+                        .GroupBy(t => t.ProjectId)
+                        .OrderByDescending(pg => pg.Sum(t => t.Duration.TotalSeconds))
+                        .First();
+
+                    var topProjectName = topProject.First().Project?.Name ?? "None";
+                    var topProjectSeconds = topProject.Sum(t => t.Duration.TotalSeconds);
+
+                    return new AnalyticsExportDto
+                    {
+                        Month = new DateTime(g.Key.Year, g.Key.Month, 1).ToString("yyyy MMM"),
+                        TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
+                        TopProject = topProjectName,
+                        TopProjectHours = FormatDuration(TimeSpan.FromSeconds(topProjectSeconds)),
+                    };
+                })
+                .ToList();
+
+            return GenerateFile(exportData, format, "analytics");
+        }
+
+        private ActionResult GenerateFile<T>(List<T> data, string? format, string filePrefix)
+        {
+            var date = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            if (format?.ToLowerInvariant() == "xlsx")
+            {
+                var bytes = exportService.ToExcel(data, filePrefix);
+                return File(bytes,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    $"{filePrefix}-export-{date}.xlsx");
+            }
+
+            var csvBytes = exportService.ToCsv(data);
+            return File(csvBytes, "text/csv", $"{filePrefix}-export-{date}.csv");
+        }
+
+        private static string FormatDuration(TimeSpan duration)
+        {
+            int hours = (duration.Days * 24) + duration.Hours;
+            return $"{hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+        }
+    }
+}

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -15,7 +15,6 @@ namespace Timinute.Server.Controllers
     public class ExportController : ControllerBase
     {
         private readonly IRepository<TrackedTask> taskRepository;
-        private readonly IRepository<Project> projectRepository;
         private readonly IExportService exportService;
         private readonly ILogger<ExportController> logger;
 
@@ -25,7 +24,6 @@ namespace Timinute.Server.Controllers
             this.logger = logger;
 
             taskRepository = repositoryFactory.GetRepository<TrackedTask>();
-            projectRepository = repositoryFactory.GetRepository<Project>();
         }
 
         [HttpGet("tasks")]
@@ -58,6 +56,7 @@ namespace Timinute.Server.Controllers
                 Date = t.StartDate.ToString("yyyy-MM-dd"),
             }).ToList();
 
+            logger.LogInformation("User {UserId} exported {Count} tracked tasks as {Format}", userId, exportData.Count, format);
             return GenerateFile(exportData, format, "tracked-tasks");
         }
 
@@ -96,7 +95,8 @@ namespace Timinute.Server.Controllers
                 .Where(x => x != null)
                 .ToList();
 
-            return GenerateFile(exportData!, format, "projects");
+            logger.LogInformation("User {UserId} exported {Count} project summaries as {Format}", userId, exportData!.Count, format);
+            return GenerateFile(exportData, format, "projects");
         }
 
         [HttpGet("analytics")]
@@ -137,6 +137,7 @@ namespace Timinute.Server.Controllers
                 })
                 .ToList();
 
+            logger.LogInformation("User {UserId} exported {Count} monthly analytics as {Format}", userId, exportData.Count, format);
             return GenerateFile(exportData, format, "analytics");
         }
 

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -43,21 +43,23 @@ namespace Timinute.Server.Controllers
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
                     && (projectId == null || t.ProjectId == projectId)
-                    && (search == null || t.Name.Contains(search)),
+                    && (search == null || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                orderBy: t => t.OrderByDescending(x => x.StartDate),
                 includeProperties: nameof(Project));
 
             var exportData = tasks.Select(t => new TaskExportDto
             {
-                Name = t.Name,
-                ProjectName = t.Project?.Name ?? "None",
+                Name = SanitizeForExport(t.Name),
+                ProjectName = SanitizeForExport(t.Project?.Name ?? "None"),
                 StartDate = t.StartDate.ToString("yyyy-MM-dd HH:mm"),
                 EndDate = t.EndDate?.ToString("yyyy-MM-dd HH:mm") ?? "",
                 Duration = FormatDuration(t.Duration),
                 Date = t.StartDate.ToString("yyyy-MM-dd"),
             }).ToList();
 
-            logger.LogInformation("User {UserId} exported {Count} tracked tasks as {Format}", userId, exportData.Count, format);
-            return GenerateFile(exportData, format, "tracked-tasks");
+            var resolvedFormat = ResolveFormat(format);
+            logger.LogInformation("User exported {Count} tracked tasks as {Format}", exportData.Count, resolvedFormat);
+            return GenerateFile(exportData, resolvedFormat, "tracked-tasks");
         }
 
         [HttpGet("projects")]
@@ -77,26 +79,23 @@ namespace Timinute.Server.Controllers
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime()),
                 includeProperties: nameof(Project));
 
-            var exportData = tasks
-                .GroupBy(t => t.ProjectId ?? "None")
-                .Select(g =>
-                {
-                    var projectName = g.First().Project?.Name ?? "None";
-                    if (!string.IsNullOrEmpty(search) && !projectName.Contains(search, StringComparison.OrdinalIgnoreCase))
-                        return null;
+            var groups = tasks.GroupBy(t => t.ProjectId ?? "None");
 
-                    return new ProjectExportDto
-                    {
-                        ProjectName = projectName,
-                        TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
-                        TaskCount = g.Count(),
-                    };
-                })
-                .Where(x => x != null)
-                .ToList();
+            if (!string.IsNullOrEmpty(search))
+            {
+                groups = groups.Where(g => (g.First().Project?.Name ?? "None").Contains(search, StringComparison.OrdinalIgnoreCase));
+            }
 
-            logger.LogInformation("User {UserId} exported {Count} project summaries as {Format}", userId, exportData!.Count, format);
-            return GenerateFile(exportData, format, "projects");
+            var exportData = groups.Select(g => new ProjectExportDto
+            {
+                ProjectName = SanitizeForExport(g.First().Project?.Name ?? "None"),
+                TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
+                TaskCount = g.Count(),
+            }).ToList();
+
+            var resolvedFormat = ResolveFormat(format);
+            logger.LogInformation("User exported {Count} project summaries as {Format}", exportData.Count, resolvedFormat);
+            return GenerateFile(exportData, resolvedFormat, "projects");
         }
 
         [HttpGet("analytics")]
@@ -131,21 +130,22 @@ namespace Timinute.Server.Controllers
                     {
                         Month = new DateTime(g.Key.Year, g.Key.Month, 1).ToString("yyyy MMM"),
                         TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
-                        TopProject = topProjectName,
+                        TopProject = SanitizeForExport(topProjectName),
                         TopProjectHours = FormatDuration(TimeSpan.FromSeconds(topProjectSeconds)),
                     };
                 })
                 .ToList();
 
-            logger.LogInformation("User {UserId} exported {Count} monthly analytics as {Format}", userId, exportData.Count, format);
-            return GenerateFile(exportData, format, "analytics");
+            var resolvedFormat = ResolveFormat(format);
+            logger.LogInformation("User exported {Count} monthly analytics as {Format}", exportData.Count, resolvedFormat);
+            return GenerateFile(exportData, resolvedFormat, "analytics");
         }
 
-        private ActionResult GenerateFile<T>(List<T> data, string? format, string filePrefix)
+        private ActionResult GenerateFile<T>(List<T> data, string resolvedFormat, string filePrefix)
         {
             var date = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
-            if (format?.ToLowerInvariant() == "xlsx")
+            if (resolvedFormat == "xlsx")
             {
                 var bytes = exportService.ToExcel(data, filePrefix);
                 return File(bytes,
@@ -157,10 +157,27 @@ namespace Timinute.Server.Controllers
             return File(csvBytes, "text/csv", $"{filePrefix}-export-{date}.csv");
         }
 
+        private static string ResolveFormat(string? format)
+        {
+            var normalized = format?.ToLowerInvariant();
+            return normalized == "xlsx" ? "xlsx" : "csv";
+        }
+
         private static string FormatDuration(TimeSpan duration)
         {
             int hours = (duration.Days * 24) + duration.Hours;
             return $"{hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+        }
+
+        private static string SanitizeForExport(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
+            if (value[0] is '=' or '+' or '-' or '@')
+                return "'" + value;
+
+            return value;
         }
     }
 }

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -174,8 +174,16 @@ namespace Timinute.Server.Controllers
             if (string.IsNullOrEmpty(value))
                 return value;
 
-            if (value[0] is '=' or '+' or '-' or '@')
-                return "'" + value;
+            foreach (var c in value)
+            {
+                if (char.IsWhiteSpace(c))
+                    continue;
+
+                if (c is '=' or '+' or '-' or '@')
+                    return "'" + value;
+
+                break;
+            }
 
             return value;
         }

--- a/Timinute/Server/Models/Export/AnalyticsExportDto.cs
+++ b/Timinute/Server/Models/Export/AnalyticsExportDto.cs
@@ -1,0 +1,10 @@
+namespace Timinute.Server.Models.Export
+{
+    public class AnalyticsExportDto
+    {
+        public string Month { get; set; } = null!;
+        public string TotalHours { get; set; } = null!;
+        public string TopProject { get; set; } = null!;
+        public string TopProjectHours { get; set; } = null!;
+    }
+}

--- a/Timinute/Server/Models/Export/ProjectExportDto.cs
+++ b/Timinute/Server/Models/Export/ProjectExportDto.cs
@@ -1,0 +1,9 @@
+namespace Timinute.Server.Models.Export
+{
+    public class ProjectExportDto
+    {
+        public string ProjectName { get; set; } = null!;
+        public string TotalHours { get; set; } = null!;
+        public int TaskCount { get; set; }
+    }
+}

--- a/Timinute/Server/Models/Export/TaskExportDto.cs
+++ b/Timinute/Server/Models/Export/TaskExportDto.cs
@@ -1,0 +1,12 @@
+namespace Timinute.Server.Models.Export
+{
+    public class TaskExportDto
+    {
+        public string Name { get; set; } = null!;
+        public string ProjectName { get; set; } = null!;
+        public string StartDate { get; set; } = null!;
+        public string EndDate { get; set; } = null!;
+        public string Duration { get; set; } = null!;
+        public string Date { get; set; } = null!;
+    }
+}

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -12,6 +12,7 @@ using Timinute.Server.Data;
 using Timinute.Server.Helpers;
 using Timinute.Server.Models;
 using Timinute.Server.Repository;
+using Timinute.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -239,6 +240,7 @@ void DependecyInjection()
     // DI
     builder.Services.AddScoped<IUserClaimsPrincipalFactory<ApplicationUser>, ApplicationUserClaimsPrincipalFactory>();
     builder.Services.AddTransient<IRepositoryFactory, RepositoryFactory>();
+    builder.Services.AddTransient<IExportService, ExportService>();
 }
 
 

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -240,7 +240,7 @@ void DependecyInjection()
     // DI
     builder.Services.AddScoped<IUserClaimsPrincipalFactory<ApplicationUser>, ApplicationUserClaimsPrincipalFactory>();
     builder.Services.AddTransient<IRepositoryFactory, RepositoryFactory>();
-    builder.Services.AddTransient<IExportService, ExportService>();
+    builder.Services.AddSingleton<IExportService, ExportService>();
 }
 
 

--- a/Timinute/Server/Services/ExportService.cs
+++ b/Timinute/Server/Services/ExportService.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using ClosedXML.Excel;
+using CsvHelper;
+
+namespace Timinute.Server.Services
+{
+    public class ExportService : IExportService
+    {
+        public byte[] ToCsv<T>(IEnumerable<T> data)
+        {
+            using var memoryStream = new MemoryStream();
+            using var writer = new StreamWriter(memoryStream, System.Text.Encoding.UTF8);
+            using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
+
+            csv.WriteRecords(data);
+            writer.Flush();
+
+            return memoryStream.ToArray();
+        }
+
+        public byte[] ToExcel<T>(IEnumerable<T> data, string sheetName)
+        {
+            using var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add(sheetName);
+            worksheet.Cell(1, 1).InsertTable(data);
+
+            using var memoryStream = new MemoryStream();
+            workbook.SaveAs(memoryStream);
+
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/Timinute/Server/Services/ExportService.cs
+++ b/Timinute/Server/Services/ExportService.cs
@@ -22,7 +22,20 @@ namespace Timinute.Server.Services
         {
             using var workbook = new XLWorkbook();
             var worksheet = workbook.Worksheets.Add(sheetName);
-            worksheet.Cell(1, 1).InsertTable(data);
+
+            var dataList = data.ToList();
+            if (dataList.Count > 0)
+            {
+                worksheet.Cell(1, 1).InsertTable(dataList);
+            }
+            else
+            {
+                var properties = typeof(T).GetProperties();
+                for (int i = 0; i < properties.Length; i++)
+                {
+                    worksheet.Cell(1, i + 1).Value = properties[i].Name;
+                }
+            }
 
             using var memoryStream = new MemoryStream();
             workbook.SaveAs(memoryStream);

--- a/Timinute/Server/Services/IExportService.cs
+++ b/Timinute/Server/Services/IExportService.cs
@@ -1,0 +1,8 @@
+namespace Timinute.Server.Services
+{
+    public interface IExportService
+    {
+        byte[] ToCsv<T>(IEnumerable<T> data);
+        byte[] ToExcel<T>(IEnumerable<T> data, string sheetName);
+    }
+}

--- a/Timinute/Server/Timinute.Server.csproj
+++ b/Timinute/Server/Timinute.Server.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />

--- a/docs/superpowers/plans/2026-04-01-data-export.md
+++ b/docs/superpowers/plans/2026-04-01-data-export.md
@@ -341,7 +341,7 @@ git commit -m "test: add Excel export tests"
 In `Timinute/Server/Program.cs`, in the `DependecyInjection()` method, add:
 
 ```csharp
-builder.Services.AddTransient<IExportService, ExportService>();
+builder.Services.AddSingleton<IExportService, ExportService>();
 ```
 
 Add the using at the function scope or file level:

--- a/docs/superpowers/plans/2026-04-01-data-export.md
+++ b/docs/superpowers/plans/2026-04-01-data-export.md
@@ -1,0 +1,713 @@
+# Data Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CSV and Excel export endpoints for tracked tasks, project summaries, and monthly analytics.
+
+**Architecture:** New `ExportController` with three GET endpoints returning `FileContentResult`. An `IExportService` handles CSV (CsvHelper) and Excel (ClosedXML) generation. Export DTOs provide flat, formatted data. Repository queries with optional filters feed the export pipeline.
+
+**Tech Stack:** .NET 10, CsvHelper, ClosedXML, xUnit, Moq, EF Core InMemory
+
+---
+
+### Task 1: Add NuGet packages
+
+**Files:**
+- Modify: `Timinute/Server/Timinute.Server.csproj`
+
+- [ ] **Step 1: Add CsvHelper and ClosedXML packages**
+
+```bash
+cd Timinute/Server
+dotnet add package CsvHelper
+dotnet add package ClosedXML
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+dotnet build Timinute.sln
+```
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Timinute/Server/Timinute.Server.csproj
+git commit -m "chore: add CsvHelper and ClosedXML packages for data export"
+```
+
+---
+
+### Task 2: Create export DTOs
+
+**Files:**
+- Create: `Timinute/Server/Models/Export/TaskExportDto.cs`
+- Create: `Timinute/Server/Models/Export/ProjectExportDto.cs`
+- Create: `Timinute/Server/Models/Export/AnalyticsExportDto.cs`
+
+- [ ] **Step 1: Create TaskExportDto**
+
+```csharp
+namespace Timinute.Server.Models.Export
+{
+    public class TaskExportDto
+    {
+        public string Name { get; set; } = null!;
+        public string ProjectName { get; set; } = null!;
+        public string StartDate { get; set; } = null!;
+        public string EndDate { get; set; } = null!;
+        public string Duration { get; set; } = null!;
+        public string Date { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 2: Create ProjectExportDto**
+
+```csharp
+namespace Timinute.Server.Models.Export
+{
+    public class ProjectExportDto
+    {
+        public string ProjectName { get; set; } = null!;
+        public string TotalHours { get; set; } = null!;
+        public int TaskCount { get; set; }
+    }
+}
+```
+
+- [ ] **Step 3: Create AnalyticsExportDto**
+
+```csharp
+namespace Timinute.Server.Models.Export
+{
+    public class AnalyticsExportDto
+    {
+        public string Month { get; set; } = null!;
+        public string TotalHours { get; set; } = null!;
+        public string TopProject { get; set; } = null!;
+        public string TopProjectHours { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+dotnet build Timinute.sln
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Server/Models/Export/
+git commit -m "feat: add export DTOs for tasks, projects, and analytics"
+```
+
+---
+
+### Task 3: Create ExportService with CSV support
+
+**Files:**
+- Create: `Timinute/Server/Services/IExportService.cs`
+- Create: `Timinute/Server/Services/ExportService.cs`
+- Create: `Timinute/Server.Tests/Services/ExportServiceTest.cs`
+
+- [ ] **Step 1: Create IExportService interface**
+
+```csharp
+namespace Timinute.Server.Services
+{
+    public interface IExportService
+    {
+        byte[] ToCsv<T>(IEnumerable<T> data);
+        byte[] ToExcel<T>(IEnumerable<T> data, string sheetName);
+    }
+}
+```
+
+- [ ] **Step 2: Write failing CSV test**
+
+```csharp
+using Timinute.Server.Models.Export;
+using Timinute.Server.Services;
+using Xunit;
+
+namespace Timinute.Server.Tests.Services
+{
+    public class ExportServiceTest
+    {
+        private readonly ExportService _exportService;
+
+        public ExportServiceTest()
+        {
+            _exportService = new ExportService();
+        }
+
+        [Fact]
+        public void ToCsv_Returns_Valid_Csv_With_Headers_And_Rows()
+        {
+            var data = new List<TaskExportDto>
+            {
+                new TaskExportDto { Name = "Task 1", ProjectName = "Project A", StartDate = "2026-04-01 09:00", EndDate = "2026-04-01 11:00", Duration = "02:00:00", Date = "2026-04-01" },
+                new TaskExportDto { Name = "Task 2", ProjectName = "Project B", StartDate = "2026-04-01 13:00", EndDate = "2026-04-01 15:00", Duration = "02:00:00", Date = "2026-04-01" },
+            };
+
+            var result = _exportService.ToCsv(data);
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
+
+            var csv = System.Text.Encoding.UTF8.GetString(result);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Equal(3, lines.Length); // header + 2 rows
+            Assert.Contains("Name", lines[0]);
+            Assert.Contains("ProjectName", lines[0]);
+            Assert.Contains("Task 1", lines[1]);
+            Assert.Contains("Task 2", lines[2]);
+        }
+
+        [Fact]
+        public void ToCsv_Empty_Data_Returns_Headers_Only()
+        {
+            var data = new List<TaskExportDto>();
+
+            var result = _exportService.ToCsv(data);
+
+            Assert.NotNull(result);
+            var csv = System.Text.Encoding.UTF8.GetString(result);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Single(lines); // header only
+            Assert.Contains("Name", lines[0]);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportServiceTest.ToCsv_Returns_Valid_Csv"
+```
+Expected: FAIL (ExportService doesn't exist yet)
+
+- [ ] **Step 4: Implement ExportService with CSV**
+
+```csharp
+using System.Globalization;
+using ClosedXML.Excel;
+using CsvHelper;
+
+namespace Timinute.Server.Services
+{
+    public class ExportService : IExportService
+    {
+        public byte[] ToCsv<T>(IEnumerable<T> data)
+        {
+            using var memoryStream = new MemoryStream();
+            using var writer = new StreamWriter(memoryStream, System.Text.Encoding.UTF8);
+            using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
+
+            csv.WriteRecords(data);
+            writer.Flush();
+
+            return memoryStream.ToArray();
+        }
+
+        public byte[] ToExcel<T>(IEnumerable<T> data, string sheetName)
+        {
+            using var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add(sheetName);
+            worksheet.Cell(1, 1).InsertTable(data);
+
+            using var memoryStream = new MemoryStream();
+            workbook.SaveAs(memoryStream);
+
+            return memoryStream.ToArray();
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run CSV tests to verify they pass**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportServiceTest.ToCsv"
+```
+Expected: PASS (both tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Services/ Timinute/Server.Tests/Services/
+git commit -m "feat: add ExportService with CSV support"
+```
+
+---
+
+### Task 4: Add Excel tests to ExportService
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Services/ExportServiceTest.cs`
+
+- [ ] **Step 1: Write Excel tests**
+
+Add to `ExportServiceTest.cs`:
+
+```csharp
+[Fact]
+public void ToExcel_Returns_Valid_Xlsx_With_Data()
+{
+    var data = new List<TaskExportDto>
+    {
+        new TaskExportDto { Name = "Task 1", ProjectName = "Project A", StartDate = "2026-04-01 09:00", EndDate = "2026-04-01 11:00", Duration = "02:00:00", Date = "2026-04-01" },
+        new TaskExportDto { Name = "Task 2", ProjectName = "Project B", StartDate = "2026-04-01 13:00", EndDate = "2026-04-01 15:00", Duration = "02:00:00", Date = "2026-04-01" },
+    };
+
+    var result = _exportService.ToExcel(data, "Tasks");
+
+    Assert.NotNull(result);
+    Assert.True(result.Length > 0);
+
+    // Verify it's a valid Excel file by reading it back
+    using var stream = new MemoryStream(result);
+    using var workbook = new XLWorkbook(stream);
+
+    Assert.Single(workbook.Worksheets);
+    Assert.Equal("Tasks", workbook.Worksheets.First().Name);
+
+    var worksheet = workbook.Worksheets.First();
+    // InsertTable creates header row + data rows
+    Assert.Equal(3, worksheet.RowsUsed().Count()); // header + 2 rows
+}
+
+[Fact]
+public void ToExcel_Empty_Data_Returns_Valid_Xlsx()
+{
+    var data = new List<TaskExportDto>();
+
+    var result = _exportService.ToExcel(data, "Empty");
+
+    Assert.NotNull(result);
+    Assert.True(result.Length > 0);
+
+    using var stream = new MemoryStream(result);
+    using var workbook = new XLWorkbook(stream);
+
+    Assert.Equal("Empty", workbook.Worksheets.First().Name);
+}
+```
+
+Add at top of file:
+```csharp
+using ClosedXML.Excel;
+```
+
+- [ ] **Step 2: Run Excel tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportServiceTest.ToExcel"
+```
+Expected: PASS
+
+- [ ] **Step 3: Run all export tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportServiceTest"
+```
+Expected: 4/4 pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Server.Tests/Services/ExportServiceTest.cs
+git commit -m "test: add Excel export tests"
+```
+
+---
+
+### Task 5: Create ExportController with tasks endpoint
+
+**Files:**
+- Create: `Timinute/Server/Controllers/ExportController.cs`
+- Modify: `Timinute/Server/Program.cs` (register IExportService)
+- Create: `Timinute/Server.Tests/Controllers/ExportControllerTest.cs`
+
+- [ ] **Step 1: Register ExportService in DI**
+
+In `Timinute/Server/Program.cs`, in the `DependecyInjection()` method, add:
+
+```csharp
+builder.Services.AddTransient<IExportService, ExportService>();
+```
+
+Add the using at the function scope or file level:
+```csharp
+using Timinute.Server.Services;
+```
+
+- [ ] **Step 2: Write failing test for task export**
+
+Create `Timinute/Server.Tests/Controllers/ExportControllerTest.cs`:
+
+```csharp
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading.Tasks;
+using Timinute.Server.Controllers;
+using Timinute.Server.Data;
+using Timinute.Server.Repository;
+using Timinute.Server.Services;
+using Timinute.Server.Tests.Helpers;
+using System.Security.Claims;
+using Xunit;
+
+namespace Timinute.Server.Tests.Controllers
+{
+    public class ExportControllerTest : ControllerTestBase<ExportController>
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<ILogger<ExportController>> _loggerMock;
+        private readonly IExportService _exportService;
+
+        private const string _databaseName = "ExportController_Test_DB";
+
+        public ExportControllerTest()
+        {
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+            _mapper = new Mapper(configuration);
+
+            _loggerMock = new Mock<ILogger<ExportController>>();
+            _exportService = new ExportService();
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Csv_Returns_File()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportTasks("csv", null, null, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("text/csv", fileResult!.ContentType);
+            Assert.Contains("tracked-tasks-export-", fileResult.FileDownloadName);
+            Assert.EndsWith(".csv", fileResult.FileDownloadName);
+            Assert.True(fileResult.FileContents.Length > 0);
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Xlsx_Returns_File()
+        {
+            ExportController controller = await CreateController();
+
+            var actionResult = await controller.ExportTasks("xlsx", null, null, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsType<FileContentResult>(actionResult);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+            Assert.Equal("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileResult!.ContentType);
+            Assert.EndsWith(".xlsx", fileResult!.FileDownloadName);
+        }
+
+        [Fact]
+        public async Task Export_Tasks_With_DateRange_Filters()
+        {
+            ExportController controller = await CreateController();
+
+            // Seed data has tasks on 2021-10-01. Filter to include them.
+            var from = new DateTime(2021, 10, 1);
+            var to = new DateTime(2021, 10, 31);
+
+            var actionResult = await controller.ExportTasks("csv", from, to, null, null);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult!.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            // ApplicationUser1 has 4 tasks in seed data, all on 2021-10-01
+            Assert.Equal(5, lines.Length); // header + 4 data rows
+        }
+
+        [Fact]
+        public async Task Export_Tasks_Another_User_Returns_Empty_File()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "AuthTest");
+            ExportController controller = await CreateController(applicationDbContext, "NonExistentUser");
+
+            var actionResult = await controller.ExportTasks("csv", null, null, null, null);
+
+            var fileResult = actionResult as FileContentResult;
+            Assert.NotNull(fileResult);
+
+            var csv = System.Text.Encoding.UTF8.GetString(fileResult!.FileContents);
+            var lines = csv.Trim().Split('\n');
+
+            Assert.Single(lines); // header only, no data
+        }
+
+        protected override async Task<ExportController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
+        {
+            if (applicationDbContext == null)
+            {
+                applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName);
+            }
+
+            var repositoryFactory = new RepositoryFactory(applicationDbContext);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {
+                new Claim("sub", userId),
+                new Claim(ClaimTypes.Name, "test1@email.com")
+            }));
+
+            ExportController controller = new(repositoryFactory, _exportService, _loggerMock.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = user }
+                }
+            };
+
+            return controller;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportControllerTest"
+```
+Expected: FAIL (ExportController doesn't exist)
+
+- [ ] **Step 4: Implement ExportController with tasks endpoint**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Timinute.Server.Helpers;
+using Timinute.Server.Models;
+using Timinute.Server.Models.Export;
+using Timinute.Server.Repository;
+using Timinute.Server.Services;
+
+namespace Timinute.Server.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class ExportController : ControllerBase
+    {
+        private readonly IRepository<TrackedTask> taskRepository;
+        private readonly IRepository<Project> projectRepository;
+        private readonly IExportService exportService;
+        private readonly ILogger<ExportController> logger;
+
+        public ExportController(IRepositoryFactory repositoryFactory, IExportService exportService, ILogger<ExportController> logger)
+        {
+            this.exportService = exportService;
+            this.logger = logger;
+
+            taskRepository = repositoryFactory.GetRepository<TrackedTask>();
+            projectRepository = repositoryFactory.GetRepository<Project>();
+        }
+
+        [HttpGet("tasks")]
+        public async Task<ActionResult> ExportTasks(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null,
+            [FromQuery] string? projectId = null,
+            [FromQuery] string? search = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime())
+                    && (projectId == null || t.ProjectId == projectId)
+                    && (search == null || t.Name.Contains(search)),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks.Select(t => new TaskExportDto
+            {
+                Name = t.Name,
+                ProjectName = t.Project?.Name ?? "None",
+                StartDate = t.StartDate.ToString("yyyy-MM-dd HH:mm"),
+                EndDate = t.EndDate?.ToString("yyyy-MM-dd HH:mm") ?? "",
+                Duration = FormatDuration(t.Duration),
+                Date = t.StartDate.ToString("yyyy-MM-dd"),
+            }).ToList();
+
+            return GenerateFile(exportData, format, "tracked-tasks");
+        }
+
+        [HttpGet("projects")]
+        public async Task<ActionResult> ExportProjects(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null,
+            [FromQuery] string? search = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime()),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks
+                .GroupBy(t => t.ProjectId ?? "None")
+                .Select(g =>
+                {
+                    var projectName = g.First().Project?.Name ?? "None";
+                    if (!string.IsNullOrEmpty(search) && !projectName.Contains(search, StringComparison.OrdinalIgnoreCase))
+                        return null;
+
+                    return new ProjectExportDto
+                    {
+                        ProjectName = projectName,
+                        TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
+                        TaskCount = g.Count(),
+                    };
+                })
+                .Where(x => x != null)
+                .ToList();
+
+            return GenerateFile(exportData!, format, "projects");
+        }
+
+        [HttpGet("analytics")]
+        public async Task<ActionResult> ExportAnalytics(
+            [FromQuery] string? format = "csv",
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            var tasks = await taskRepository.Get(
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime()),
+                includeProperties: nameof(Project));
+
+            var exportData = tasks
+                .GroupBy(t => new { t.StartDate.Year, t.StartDate.Month })
+                .Select(g =>
+                {
+                    var topProject = g
+                        .GroupBy(t => t.ProjectId)
+                        .OrderByDescending(pg => pg.Sum(t => t.Duration.TotalSeconds))
+                        .First();
+
+                    var topProjectName = topProject.First().Project?.Name ?? "None";
+                    var topProjectSeconds = topProject.Sum(t => t.Duration.TotalSeconds);
+
+                    return new AnalyticsExportDto
+                    {
+                        Month = new DateTime(g.Key.Year, g.Key.Month, 1).ToString("yyyy MMM"),
+                        TotalHours = FormatDuration(TimeSpan.FromSeconds(g.Sum(t => t.Duration.TotalSeconds))),
+                        TopProject = topProjectName,
+                        TopProjectHours = FormatDuration(TimeSpan.FromSeconds(topProjectSeconds)),
+                    };
+                })
+                .ToList();
+
+            return GenerateFile(exportData, format, "analytics");
+        }
+
+        private ActionResult GenerateFile<T>(List<T> data, string? format, string filePrefix)
+        {
+            var date = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            if (format?.ToLowerInvariant() == "xlsx")
+            {
+                var bytes = exportService.ToExcel(data, filePrefix);
+                return File(bytes,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    $"{filePrefix}-export-{date}.xlsx");
+            }
+
+            var csvBytes = exportService.ToCsv(data);
+            return File(csvBytes, "text/csv", $"{filePrefix}-export-{date}.csv");
+        }
+
+        private static string FormatDuration(TimeSpan duration)
+        {
+            int hours = (duration.Days * 24) + duration.Hours;
+            return $"{hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run controller tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~ExportControllerTest"
+```
+Expected: 4/4 pass
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+dotnet test
+```
+Expected: 54+ tests pass (50 existing + 4 export service + 4 controller)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Timinute/Server/Controllers/ExportController.cs Timinute/Server/Program.cs Timinute/Server.Tests/Controllers/ExportControllerTest.cs
+git commit -m "feat: add ExportController with tasks, projects, and analytics endpoints"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Clean build**
+
+```bash
+dotnet clean Timinute.sln && dotnet build Timinute.sln
+```
+Expected: 0 errors
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+dotnet test --verbosity normal
+```
+Expected: All tests pass (58 total: 50 existing + 4 export service + 4 controller)
+
+- [ ] **Step 3: Verify git status**
+
+```bash
+git status
+```
+Expected: Clean working tree

--- a/docs/superpowers/specs/2026-04-01-data-export-design.md
+++ b/docs/superpowers/specs/2026-04-01-data-export-design.md
@@ -79,7 +79,7 @@ public interface IExportService
 
 ### ExportService
 
-Single implementation using CsvHelper for CSV and ClosedXML for Excel. Registered as singleton in DI (stateless, thread-safe). Includes CSV injection protection via a custom string converter that escapes formula-triggering characters.
+Single implementation using CsvHelper for CSV and ClosedXML for Excel. Registered as singleton in DI (stateless, thread-safe). CSV injection protection is applied at the controller level via `SanitizeForExport()` which prefixes formula-triggering characters (`=`, `+`, `-`, `@`) with a single quote on all user-controlled string fields during DTO mapping.
 
 - `ToCsv<T>`: Uses CsvHelper to write headers + rows to a MemoryStream, returns bytes.
 - `ToExcel<T>`: Creates XLWorkbook with one worksheet, inserts headers from property names, fills rows, returns bytes.

--- a/docs/superpowers/specs/2026-04-01-data-export-design.md
+++ b/docs/superpowers/specs/2026-04-01-data-export-design.md
@@ -34,7 +34,7 @@ Returns tracked tasks for the current user.
 
 Columns: Name, ProjectName, StartDate, EndDate, Duration (HH:mm:ss), Date (yyyy-MM-dd)
 
-Sorted by StartDate desc. Includes Project navigation property for ProjectName.
+Sorted by StartDate descending. Includes Project navigation property for ProjectName.
 
 ### GET /export/projects
 
@@ -79,7 +79,7 @@ public interface IExportService
 
 ### ExportService
 
-Single implementation using CsvHelper for CSV and ClosedXML for Excel. Registered as transient in DI.
+Single implementation using CsvHelper for CSV and ClosedXML for Excel. Registered as singleton in DI (stateless, thread-safe). Includes CSV injection protection via a custom string converter that escapes formula-triggering characters.
 
 - `ToCsv<T>`: Uses CsvHelper to write headers + rows to a MemoryStream, returns bytes.
 - `ToExcel<T>`: Creates XLWorkbook with one worksheet, inserts headers from property names, fills rows, returns bytes.

--- a/docs/superpowers/specs/2026-04-01-data-export-design.md
+++ b/docs/superpowers/specs/2026-04-01-data-export-design.md
@@ -1,0 +1,143 @@
+# Data Export Feature Design
+
+## Goal
+
+Add CSV and Excel (.xlsx) export for tracked tasks, project summaries, and monthly analytics via server-side API endpoints.
+
+## Scope
+
+- Three new API endpoints on an `ExportController`
+- CSV generation via CsvHelper library
+- Excel generation via ClosedXML library
+- Optional filtering: date range, project, search term
+- Export DTOs for flat/formatted output
+- Unit tests for services and controller
+
+Out of scope: PDF export, client-side UI buttons (API only for now), scheduled/email reports.
+
+## New Dependencies
+
+- `CsvHelper` (latest stable) — CSV serialization
+- `ClosedXML` (latest stable, MIT license) — Excel generation
+
+Both added to `Timinute/Server/Timinute.Server.csproj`.
+
+## API Endpoints
+
+All on `ExportController`, `[Authorize]`, route prefix `[controller]`.
+
+### GET /export/tasks
+
+Query params: `format` (csv|xlsx), `from` (DateTime?), `to` (DateTime?), `projectId` (string?), `search` (string?)
+
+Returns tracked tasks for the current user.
+
+Columns: Name, ProjectName, StartDate, EndDate, Duration (HH:mm:ss), Date (yyyy-MM-dd)
+
+Sorted by StartDate desc. Includes Project navigation property for ProjectName.
+
+### GET /export/projects
+
+Query params: `format` (csv|xlsx), `from` (DateTime?), `to` (DateTime?), `search` (string?)
+
+Returns per-project summary for the current user.
+
+Columns: ProjectName, TotalHours (HH:mm:ss), TaskCount
+
+Aggregates tracked task durations grouped by project. Filters apply to the underlying tasks (date range limits which tasks count toward totals).
+
+### GET /export/analytics
+
+Query params: `format` (csv|xlsx), `from` (DateTime?), `to` (DateTime?)
+
+Returns monthly work time analytics for the current user.
+
+Columns: Month (yyyy MMM), TotalHours (HH:mm:ss), TopProject, TopProjectHours (HH:mm:ss)
+
+One row per month. Filters limit which months are included.
+
+### Response
+
+All endpoints return `FileContentResult` with:
+- Content type: `text/csv` or `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+- `Content-Disposition: attachment; filename="<type>-export-<yyyy-MM-dd>.<ext>"`
+- Example: `tracked-tasks-export-2026-04-01.csv`
+
+Invalid or missing `format` defaults to CSV.
+
+## Export Services
+
+### IExportService
+
+```csharp
+public interface IExportService
+{
+    byte[] ToCsv<T>(IEnumerable<T> data);
+    byte[] ToExcel<T>(IEnumerable<T> data, string sheetName);
+}
+```
+
+### ExportService
+
+Single implementation using CsvHelper for CSV and ClosedXML for Excel. Registered as transient in DI.
+
+- `ToCsv<T>`: Uses CsvHelper to write headers + rows to a MemoryStream, returns bytes.
+- `ToExcel<T>`: Creates XLWorkbook with one worksheet, inserts headers from property names, fills rows, returns bytes.
+
+## Export DTOs
+
+Server-only DTOs in `Timinute/Server/Models/Export/`:
+
+### TaskExportDto
+- `Name` (string)
+- `ProjectName` (string)
+- `StartDate` (string, formatted yyyy-MM-dd HH:mm)
+- `EndDate` (string, formatted yyyy-MM-dd HH:mm)
+- `Duration` (string, formatted HH:mm:ss)
+- `Date` (string, formatted yyyy-MM-dd)
+
+### ProjectExportDto
+- `ProjectName` (string)
+- `TotalHours` (string, formatted HH:mm:ss)
+- `TaskCount` (int)
+
+### AnalyticsExportDto
+- `Month` (string, formatted yyyy MMM)
+- `TotalHours` (string, formatted HH:mm:ss)
+- `TopProject` (string)
+- `TopProjectHours` (string, formatted HH:mm:ss)
+
+## Data Flow
+
+1. Client calls `GET /export/tasks?format=xlsx&from=2026-03-01&to=2026-03-31`
+2. Controller extracts userId from JWT claims
+3. Controller queries repository with filters (date range, projectId, search)
+4. Controller maps entity results to export DTOs with formatted strings
+5. Controller passes DTOs to `IExportService.ToExcel()` or `ToCsv()`
+6. Controller returns `FileContentResult` with bytes and appropriate headers
+
+## Files to Create
+
+- `Timinute/Server/Controllers/ExportController.cs`
+- `Timinute/Server/Services/IExportService.cs`
+- `Timinute/Server/Services/ExportService.cs`
+- `Timinute/Server/Models/Export/TaskExportDto.cs`
+- `Timinute/Server/Models/Export/ProjectExportDto.cs`
+- `Timinute/Server/Models/Export/AnalyticsExportDto.cs`
+
+## Files to Modify
+
+- `Timinute/Server/Timinute.Server.csproj` (add CsvHelper, ClosedXML)
+- `Timinute/Server/Program.cs` (register IExportService)
+
+## Test Plan
+
+### Export Service Tests
+- `CsvExportService_Returns_Valid_Csv` — verify headers and row count
+- `ExcelExportService_Returns_Valid_Xlsx` — verify parseable Excel with correct sheet and row count
+
+### Controller Tests
+- `Export_Tasks_Csv_Returns_File` — verify FileContentResult with text/csv
+- `Export_Tasks_Xlsx_Returns_File` — verify FileContentResult with Excel content type
+- `Export_Tasks_With_DateRange_Filters` — verify only tasks within range exported
+- `Export_Tasks_Another_User_Returns_Empty` — verify user isolation


### PR DESCRIPTION
## Summary

- Add CSV and Excel (.xlsx) export for tracked tasks, project summaries, and monthly analytics
- Three new API endpoints on ExportController with optional filtering (date range, project, search)
- CsvHelper for CSV generation, ClosedXML for Excel generation
- 10 new tests (4 export service + 6 controller)

## New Endpoints

| Endpoint | Formats | Filters |
|----------|---------|---------|
| `GET /export/tasks` | csv, xlsx | from, to, projectId, search |
| `GET /export/projects` | csv, xlsx | from, to, search |
| `GET /export/analytics` | csv, xlsx | from, to |

All endpoints return `FileContentResult` with `Content-Disposition: attachment`.

## New Dependencies

- `CsvHelper` (Apache 2.0) — CSV serialization
- `ClosedXML` (MIT) — Excel generation

## Test plan

- [x] `dotnet build Timinute.sln` — 0 errors
- [x] `dotnet test` — 60/60 passing (50 existing + 10 new)
- [x] CSV export returns valid headers and data rows
- [x] Excel export returns parseable .xlsx with correct sheet name
- [x] Date range filtering returns only matching tasks
- [x] User isolation — non-owner gets empty export (header only)
- [x] Projects and analytics endpoints return grouped/aggregated data