### PR TITLE
Add search/filter endpoints for tracked tasks and projects

### DIFF
--- a/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -259,6 +260,55 @@ namespace Timinute.Server.Tests.Controllers
             var notFoundResult = actionResult.Result as NotFoundObjectResult;
             Assert.NotNull(notFoundResult);
             Assert.Equal("Project not found!", notFoundResult!.Value);
+        }
+
+        [Fact]
+        public async Task Search_Projects_By_Name()
+        {
+            ProjectController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchProjects(pagingParams, "Project 1", null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+            var projects = okResult!.Value as IEnumerable<ProjectDto>;
+            Assert.NotNull(projects);
+            Assert.Single(projects!);
+            Assert.Equal("ProjectId1", projects!.First().ProjectId);
+        }
+
+        [Fact]
+        public async Task Search_Projects_By_MinTaskCount()
+        {
+            ProjectController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchProjects(pagingParams, null, 1);
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var projects = okResult!.Value as IEnumerable<ProjectDto>;
+            Assert.NotNull(projects);
+            Assert.Single(projects!);
+            Assert.Equal("ProjectId1", projects!.First().ProjectId);
+        }
+
+        [Fact]
+        public async Task Search_Projects_Another_User_Empty()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchAuthTest");
+            ProjectController controller = await CreateController(applicationDbContext, "NonExistentUser");
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchProjects(pagingParams, null, null);
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var projects = okResult!.Value as IEnumerable<ProjectDto>;
+            Assert.NotNull(projects);
+            Assert.Empty(projects!);
         }
 
         protected override async Task<ProjectController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Timinute.Server.Controllers;
@@ -340,6 +341,88 @@ namespace Timinute.Server.Tests.Controllers
             var badRequestResult = actionResult.Result as BadRequestObjectResult;
             Assert.NotNull(badRequestResult);
             Assert.Equal("End date must be strictly after start date.", badRequestResult!.Value);
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_DateRange()
+        {
+            TrackedTaskController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+            var from = new DateTimeOffset(2021, 10, 1, 0, 0, 0, TimeSpan.Zero);
+            var to = new DateTimeOffset(2021, 10, 31, 0, 0, 0, TimeSpan.Zero);
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, from, to, null, null);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Equal(4, tasks!.Count());
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_ProjectId()
+        {
+            TrackedTaskController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, "ProjectId1", null);
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Equal(3, tasks!.Count());
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_Name()
+        {
+            TrackedTaskController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, "Task 1");
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Single(tasks!);
+            Assert.Equal("TrackedTaskId1", tasks!.First().TaskId);
+        }
+
+        [Fact]
+        public async Task Search_Tasks_Combined_Filters()
+        {
+            TrackedTaskController controller = await CreateController();
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+            var from = new DateTimeOffset(2021, 10, 1, 0, 0, 0, TimeSpan.Zero);
+            var to = new DateTimeOffset(2021, 10, 31, 0, 0, 0, TimeSpan.Zero);
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, from, to, "ProjectId1", "Task");
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Equal(3, tasks!.Count());
+        }
+
+        [Fact]
+        public async Task Search_Tasks_Another_User_Empty()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchAuthTest");
+            TrackedTaskController controller = await CreateController(applicationDbContext, "NonExistentUser");
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, null);
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Empty(tasks!);
         }
 
         protected override async Task<TrackedTaskController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -38,12 +38,15 @@ namespace Timinute.Server.Controllers
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
+            var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+            var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId.Trim();
+
             var tasks = await taskRepository.Get(
                 t => t.UserId == userId
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
-                    && (projectId == null || t.ProjectId == projectId)
-                    && (search == null || t.Name.Contains(search)),
+                    && (normalizedProjectId == null || t.ProjectId == normalizedProjectId)
+                    && (normalizedSearch == null || t.Name.Contains(normalizedSearch)),
                 orderBy: t => t.OrderByDescending(x => x.StartDate),
                 includeProperties: nameof(Project));
 

--- a/Timinute/Server/Controllers/ExportController.cs
+++ b/Timinute/Server/Controllers/ExportController.cs
@@ -43,7 +43,7 @@ namespace Timinute.Server.Controllers
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
                     && (projectId == null || t.ProjectId == projectId)
-                    && (search == null || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                    && (search == null || t.Name.Contains(search)),
                 orderBy: t => t.OrderByDescending(x => x.StartDate),
                 includeProperties: nameof(Project));
 

--- a/Timinute/Server/Controllers/ProjectController.cs
+++ b/Timinute/Server/Controllers/ProjectController.cs
@@ -71,9 +71,16 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
+            if (minTaskCount.HasValue && minTaskCount.Value < 0)
+            {
+                return BadRequest("minTaskCount must be >= 0.");
+            }
+
+            var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+
             var pagedProjectList = await projectRepository.GetPaged(pagingParameters,
                 p => p.UserId == userId
-                    && (search == null || p.Name.Contains(search))
+                    && (normalizedSearch == null || p.Name.Contains(normalizedSearch))
                     && (!minTaskCount.HasValue || p.TrackedTasks!.Count >= minTaskCount.Value),
                 orderBy: nameof(Project.Name));
 

--- a/Timinute/Server/Controllers/ProjectController.cs
+++ b/Timinute/Server/Controllers/ProjectController.cs
@@ -57,6 +57,51 @@ namespace Timinute.Server.Controllers
             return Ok(mapper.Map<IEnumerable<ProjectDto>>(pagedProjectList));
         }
 
+        // GET: api/Project/search
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<ProjectDto>>> SearchProjects(
+            [FromQuery] PagingParameters pagingParameters,
+            [FromQuery] string? search = null,
+            [FromQuery] int? minTaskCount = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var projects = await projectRepository.Get(
+                p => p.UserId == userId
+                    && (search == null || p.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                includeProperties: nameof(Project.TrackedTasks));
+
+            if (minTaskCount.HasValue)
+            {
+                projects = projects.Where(p => (p.TrackedTasks?.Count ?? 0) >= minTaskCount.Value);
+            }
+
+            var projectList = projects.ToList();
+            var totalCount = projectList.Count;
+            var pagedProjects = projectList
+                .Skip((pagingParameters.PageNumber - 1) * pagingParameters.PageSize)
+                .Take(pagingParameters.PageSize)
+                .ToList();
+
+            var metadata = new PaginationHeaderDto
+            {
+                TotalCount = totalCount,
+                PageSize = pagingParameters.PageSize,
+                CurrentPage = pagingParameters.PageNumber,
+                TotalPages = (int)Math.Ceiling(totalCount / (double)pagingParameters.PageSize),
+                HasNext = pagingParameters.PageNumber * pagingParameters.PageSize < totalCount,
+                HasPrevious = pagingParameters.PageNumber > 1
+            };
+
+            Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
+            return Ok(mapper.Map<IEnumerable<ProjectDto>>(pagedProjects));
+        }
+
         // GET: api/Project
         [HttpGet("{id}")]
         public async Task<ActionResult<ProjectDto>> GetProject(string id)

--- a/Timinute/Server/Controllers/ProjectController.cs
+++ b/Timinute/Server/Controllers/ProjectController.cs
@@ -71,9 +71,11 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
+            // Use Get instead of GetPaged because minTaskCount filtering requires
+            // in-memory evaluation of the TrackedTasks collection count.
             var projects = await projectRepository.Get(
                 p => p.UserId == userId
-                    && (search == null || p.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                    && (search == null || p.Name.Contains(search)),
                 includeProperties: nameof(Project.TrackedTasks));
 
             if (minTaskCount.HasValue)

--- a/Timinute/Server/Controllers/ProjectController.cs
+++ b/Timinute/Server/Controllers/ProjectController.cs
@@ -71,37 +71,24 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            // Use Get instead of GetPaged because minTaskCount filtering requires
-            // in-memory evaluation of the TrackedTasks collection count.
-            var projects = await projectRepository.Get(
+            var pagedProjectList = await projectRepository.GetPaged(pagingParameters,
                 p => p.UserId == userId
-                    && (search == null || p.Name.Contains(search)),
-                includeProperties: nameof(Project.TrackedTasks));
-
-            if (minTaskCount.HasValue)
-            {
-                projects = projects.Where(p => (p.TrackedTasks?.Count ?? 0) >= minTaskCount.Value);
-            }
-
-            var projectList = projects.ToList();
-            var totalCount = projectList.Count;
-            var pagedProjects = projectList
-                .Skip((pagingParameters.PageNumber - 1) * pagingParameters.PageSize)
-                .Take(pagingParameters.PageSize)
-                .ToList();
+                    && (search == null || p.Name.Contains(search))
+                    && (!minTaskCount.HasValue || p.TrackedTasks!.Count >= minTaskCount.Value),
+                orderBy: nameof(Project.Name));
 
             var metadata = new PaginationHeaderDto
             {
-                TotalCount = totalCount,
-                PageSize = pagingParameters.PageSize,
-                CurrentPage = pagingParameters.PageNumber,
-                TotalPages = (int)Math.Ceiling(totalCount / (double)pagingParameters.PageSize),
-                HasNext = pagingParameters.PageNumber * pagingParameters.PageSize < totalCount,
-                HasPrevious = pagingParameters.PageNumber > 1
+                TotalCount = pagedProjectList.TotalCount,
+                PageSize = pagedProjectList.PageSize,
+                CurrentPage = pagedProjectList.CurrentPage,
+                TotalPages = pagedProjectList.TotalPages,
+                HasNext = pagedProjectList.HasNext,
+                HasPrevious = pagedProjectList.HasPrevious
             };
 
             Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
-            return Ok(mapper.Map<IEnumerable<ProjectDto>>(pagedProjects));
+            return Ok(mapper.Map<IEnumerable<ProjectDto>>(pagedProjectList));
         }
 
         // GET: api/Project

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -77,12 +77,15 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
+            var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+            var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId;
+
             var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
                 t => t.UserId == userId
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
-                    && (projectId == null || t.ProjectId == projectId)
-                    && (search == null || t.Name.Contains(search)),
+                    && (normalizedProjectId == null || t.ProjectId == normalizedProjectId)
+                    && (normalizedSearch == null || t.Name.Contains(normalizedSearch)),
                 orderBy: $"{nameof(TrackedTask.StartDate)} desc",
                 includeProperties: "Project");
 

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -78,7 +78,7 @@ namespace Timinute.Server.Controllers
             }
 
             var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
-            var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId;
+            var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId.Trim();
 
             var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
                 t => t.UserId == userId

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -61,6 +61,45 @@ namespace Timinute.Server.Controllers
             return Ok(mapper.Map<IEnumerable<TrackedTaskDto>>(pagedTrackedTaskList));
         }
 
+        // GET: api/TrackedTask/search
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<TrackedTaskDto>>> SearchTrackedTasks(
+            [FromQuery] PagingParameters pagingParameters,
+            [FromQuery] DateTimeOffset? from = null,
+            [FromQuery] DateTimeOffset? to = null,
+            [FromQuery] string? projectId = null,
+            [FromQuery] string? search = null)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
+                t => t.UserId == userId
+                    && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+                    && (to == null || t.StartDate <= to.Value.ToUniversalTime())
+                    && (projectId == null || t.ProjectId == projectId)
+                    && (search == null || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                orderBy: $"{nameof(TrackedTask.StartDate)} desc",
+                includeProperties: "Project");
+
+            var metadata = new PaginationHeaderDto
+            {
+                TotalCount = pagedTrackedTaskList.TotalCount,
+                PageSize = pagedTrackedTaskList.PageSize,
+                CurrentPage = pagedTrackedTaskList.CurrentPage,
+                TotalPages = pagedTrackedTaskList.TotalPages,
+                HasNext = pagedTrackedTaskList.HasNext,
+                HasPrevious = pagedTrackedTaskList.HasPrevious
+            };
+
+            Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
+            return Ok(mapper.Map<IEnumerable<TrackedTaskDto>>(pagedTrackedTaskList));
+        }
+
         // GET: api/TrackedTask
         [HttpGet("{id}")]
         public async Task<ActionResult<TrackedTaskDto>> GetTrackedTask(string id)

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -82,7 +82,7 @@ namespace Timinute.Server.Controllers
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
                     && (projectId == null || t.ProjectId == projectId)
-                    && (search == null || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+                    && (search == null || t.Name.Contains(search)),
                 orderBy: $"{nameof(TrackedTask.StartDate)} desc",
                 includeProperties: "Project");
 

--- a/docs/superpowers/plans/2026-04-01-advanced-filtering.md
+++ b/docs/superpowers/plans/2026-04-01-advanced-filtering.md
@@ -1,0 +1,354 @@
+# Advanced Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add search/filter endpoints for tracked tasks and projects with date range, project, name search, and task count filters.
+
+**Architecture:** New action methods on existing controllers using the repository's `GetPaged` and `Get` methods. Filter expressions built from optional query parameters combined with AND logic. TDD approach.
+
+**Tech Stack:** .NET 10, EF Core 10, xUnit, Moq, EF Core InMemory
+
+---
+
+### Task 1: Add TrackedTask search endpoint with tests (TDD)
+
+**Files:**
+- Modify: `Timinute/Server/Controllers/TrackedTaskController.cs`
+- Modify: `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs`
+
+- [ ] **Step 1: Write 5 failing tests**
+
+Add to `TrackedTaskControllerTest.cs` before the `CreateController` method:
+
+```csharp
+[Fact]
+public async Task Search_Tasks_By_DateRange()
+{
+    TrackedTaskController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var from = new DateTimeOffset(2021, 10, 1, 0, 0, 0, TimeSpan.Zero);
+    var to = new DateTimeOffset(2021, 10, 31, 0, 0, 0, TimeSpan.Zero);
+
+    var actionResult = await controller.SearchTrackedTasks(pagingParams, from, to, null, null);
+
+    Assert.NotNull(actionResult);
+    Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+    var okResult = actionResult.Result as OkObjectResult;
+    var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+    Assert.NotNull(tasks);
+    Assert.Equal(4, tasks!.Count()); // ApplicationUser1 has 4 tasks on 2021-10-01
+}
+
+[Fact]
+public async Task Search_Tasks_By_ProjectId()
+{
+    TrackedTaskController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, "ProjectId1", null);
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+    Assert.NotNull(tasks);
+    Assert.Equal(3, tasks!.Count()); // ProjectId1 has tasks 1,2,3
+}
+
+[Fact]
+public async Task Search_Tasks_By_Name()
+{
+    TrackedTaskController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, "Task 1");
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+    Assert.NotNull(tasks);
+    Assert.Single(tasks!);
+    Assert.Equal("TrackedTaskId1", tasks!.First().TaskId);
+}
+
+[Fact]
+public async Task Search_Tasks_Combined_Filters()
+{
+    TrackedTaskController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var from = new DateTimeOffset(2021, 10, 1, 0, 0, 0, TimeSpan.Zero);
+    var to = new DateTimeOffset(2021, 10, 31, 0, 0, 0, TimeSpan.Zero);
+
+    var actionResult = await controller.SearchTrackedTasks(pagingParams, from, to, "ProjectId1", "Task");
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+    Assert.NotNull(tasks);
+    Assert.Equal(3, tasks!.Count()); // ProjectId1 tasks within date range matching "Task"
+}
+
+[Fact]
+public async Task Search_Tasks_Another_User_Empty()
+{
+    ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchAuthTest");
+    TrackedTaskController controller = await CreateController(applicationDbContext, "NonExistentUser");
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, null);
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+    Assert.NotNull(tasks);
+    Assert.Empty(tasks!);
+}
+```
+
+Add required using if not present: `using System.Linq;`
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test --filter "FullyQualifiedName~Search_Tasks"
+```
+Expected: FAIL (SearchTrackedTasks method doesn't exist)
+
+- [ ] **Step 3: Implement SearchTrackedTasks**
+
+Add to `TrackedTaskController.cs` after the `GetTrackedTasks` method:
+
+```csharp
+// GET: api/TrackedTask/search
+[HttpGet("search")]
+public async Task<ActionResult<IEnumerable<TrackedTaskDto>>> SearchTrackedTasks(
+    [FromQuery] PagingParameters pagingParameters,
+    [FromQuery] DateTimeOffset? from = null,
+    [FromQuery] DateTimeOffset? to = null,
+    [FromQuery] string? projectId = null,
+    [FromQuery] string? search = null)
+{
+    var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+    if (string.IsNullOrEmpty(userId))
+    {
+        return Unauthorized();
+    }
+
+    var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
+        t => t.UserId == userId
+            && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+            && (to == null || t.StartDate <= to.Value.ToUniversalTime())
+            && (projectId == null || t.ProjectId == projectId)
+            && (search == null || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+        orderBy: $"{nameof(TrackedTask.StartDate)} desc",
+        includeProperties: "Project");
+
+    var metadata = new PaginationHeaderDto
+    {
+        TotalCount = pagedTrackedTaskList.TotalCount,
+        PageSize = pagedTrackedTaskList.PageSize,
+        CurrentPage = pagedTrackedTaskList.CurrentPage,
+        TotalPages = pagedTrackedTaskList.TotalPages,
+        HasNext = pagedTrackedTaskList.HasNext,
+        HasPrevious = pagedTrackedTaskList.HasPrevious
+    };
+
+    Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
+    return Ok(mapper.Map<IEnumerable<TrackedTaskDto>>(pagedTrackedTaskList));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet test --filter "FullyQualifiedName~Search_Tasks"
+```
+Expected: 5/5 PASS
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+dotnet test
+```
+Expected: 65/65 pass (60 existing + 5 new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Controllers/TrackedTaskController.cs Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+git commit -m "feat: add TrackedTask search endpoint with date, project, and name filters"
+```
+
+---
+
+### Task 2: Add Project search endpoint with tests (TDD)
+
+**Files:**
+- Modify: `Timinute/Server/Controllers/ProjectController.cs`
+- Modify: `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+Add to `ProjectControllerTest.cs` before the `CreateController` method:
+
+```csharp
+[Fact]
+public async Task Search_Projects_By_Name()
+{
+    ProjectController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchProjects(pagingParams, "Project 1", null);
+
+    Assert.NotNull(actionResult);
+    Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+    var okResult = actionResult.Result as OkObjectResult;
+    var projects = okResult!.Value as IEnumerable<ProjectDto>;
+    Assert.NotNull(projects);
+    Assert.Single(projects!);
+    Assert.Equal("ProjectId1", projects!.First().ProjectId);
+}
+
+[Fact]
+public async Task Search_Projects_By_MinTaskCount()
+{
+    ProjectController controller = await CreateController();
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchProjects(pagingParams, null, 1);
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var projects = okResult!.Value as IEnumerable<ProjectDto>;
+    Assert.NotNull(projects);
+    // ApplicationUser1: ProjectId1 has 3 tasks, ProjectId4/5 have 0
+    Assert.Single(projects!);
+    Assert.Equal("ProjectId1", projects!.First().ProjectId);
+}
+
+[Fact]
+public async Task Search_Projects_Another_User_Empty()
+{
+    ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchAuthTest");
+    ProjectController controller = await CreateController(applicationDbContext, "NonExistentUser");
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    var actionResult = await controller.SearchProjects(pagingParams, null, null);
+
+    Assert.NotNull(actionResult);
+    var okResult = actionResult.Result as OkObjectResult;
+    var projects = okResult!.Value as IEnumerable<ProjectDto>;
+    Assert.NotNull(projects);
+    Assert.Empty(projects!);
+}
+```
+
+Add required using if not present: `using System.Linq;`
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test --filter "FullyQualifiedName~Search_Projects"
+```
+Expected: FAIL (SearchProjects method doesn't exist)
+
+- [ ] **Step 3: Implement SearchProjects**
+
+Add to `ProjectController.cs` after the `GetProjects` method:
+
+```csharp
+// GET: api/Project/search
+[HttpGet("search")]
+public async Task<ActionResult<IEnumerable<ProjectDto>>> SearchProjects(
+    [FromQuery] PagingParameters pagingParameters,
+    [FromQuery] string? search = null,
+    [FromQuery] int? minTaskCount = null)
+{
+    var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+    if (string.IsNullOrEmpty(userId))
+    {
+        return Unauthorized();
+    }
+
+    var projects = await projectRepository.Get(
+        p => p.UserId == userId
+            && (search == null || p.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+        includeProperties: nameof(Project.TrackedTasks));
+
+    if (minTaskCount.HasValue)
+    {
+        projects = projects.Where(p => (p.TrackedTasks?.Count ?? 0) >= minTaskCount.Value);
+    }
+
+    var projectList = projects.ToList();
+    var totalCount = projectList.Count;
+    var pagedProjects = projectList
+        .Skip((pagingParameters.PageNumber - 1) * pagingParameters.PageSize)
+        .Take(pagingParameters.PageSize)
+        .ToList();
+
+    var metadata = new PaginationHeaderDto
+    {
+        TotalCount = totalCount,
+        PageSize = pagingParameters.PageSize,
+        CurrentPage = pagingParameters.PageNumber,
+        TotalPages = (int)Math.Ceiling(totalCount / (double)pagingParameters.PageSize),
+        HasNext = pagingParameters.PageNumber * pagingParameters.PageSize < totalCount,
+        HasPrevious = pagingParameters.PageNumber > 1
+    };
+
+    Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
+    return Ok(mapper.Map<IEnumerable<ProjectDto>>(pagedProjects));
+}
+```
+
+Add `using Timinute.Server.Models;` if not already present (for `nameof(Project.TrackedTasks)`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet test --filter "FullyQualifiedName~Search_Projects"
+```
+Expected: 3/3 PASS
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+dotnet test
+```
+Expected: 68/68 pass (65 + 3 new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Controllers/ProjectController.cs Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+git commit -m "feat: add Project search endpoint with name and task count filters"
+```
+
+---
+
+### Task 3: Final verification
+
+- [ ] **Step 1: Clean build**
+
+```bash
+dotnet clean Timinute.sln && dotnet build Timinute.sln
+```
+Expected: 0 errors
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+dotnet test --verbosity normal
+```
+Expected: 68/68 pass
+
+- [ ] **Step 3: Verify git status**
+
+```bash
+git status
+```
+Expected: Clean working tree

--- a/docs/superpowers/plans/2026-04-01-advanced-filtering.md
+++ b/docs/superpowers/plans/2026-04-01-advanced-filtering.md
@@ -275,7 +275,7 @@ public async Task<ActionResult<IEnumerable<ProjectDto>>> SearchProjects(
 
     var projects = await projectRepository.Get(
         p => p.UserId == userId
-            && (search == null || p.Name.Contains(search, StringComparison.OrdinalIgnoreCase)),
+            && (search == null || p.Name.Contains(search)),
         includeProperties: nameof(Project.TrackedTasks));
 
     if (minTaskCount.HasValue)

--- a/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
@@ -23,7 +23,7 @@ Query params (all optional, combined with AND):
 - `from` (`DateTimeOffset?`) — StartDate >= from
 - `to` (`DateTimeOffset?`) — StartDate <= to
 - `projectId` (`string?`) — exact match on ProjectId
-- `search` (`string?`) — case-insensitive Contains on task Name
+- `search` (`string?`) — Contains on task Name (case sensitivity depends on DB collation)
 
 Also accepts `PagingParameters` (PageNumber, PageSize) from query string.
 

--- a/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
@@ -1,0 +1,73 @@
+# Advanced Filtering Design
+
+## Goal
+
+Add search/filter endpoints for tracked tasks and projects with date range, project, name search, and task count filters.
+
+## Scope
+
+- New `GET /trackedtask/search` endpoint with date range, projectId, and name search
+- New `GET /project/search` endpoint with name search and minimum task count
+- Both paginated, user-scoped, same response format as existing list endpoints
+- Tests for all filter combinations and user isolation
+
+Out of scope: full-text search, filter persistence, client-side UI changes.
+
+## New Endpoints
+
+### GET /trackedtask/search
+
+On existing `TrackedTaskController`. `[Authorize]`.
+
+Query params (all optional, combined with AND):
+- `from` (`DateTimeOffset?`) — StartDate >= from
+- `to` (`DateTimeOffset?`) — StartDate <= to
+- `projectId` (`string?`) — exact match on ProjectId
+- `search` (`string?`) — case-insensitive Contains on task Name
+
+Also accepts `PagingParameters` (PageNumber, PageSize) from query string.
+
+Returns: `ActionResult<IEnumerable<TrackedTaskDto>>` with `X-Pagination` header.
+
+Sorted by StartDate descending. Includes Project navigation property.
+
+### GET /project/search
+
+On existing `ProjectController`. `[Authorize]`.
+
+Query params (all optional, combined with AND):
+- `search` (`string?`) — case-insensitive Contains on project Name
+- `minTaskCount` (`int?`) — only projects with at least N tracked tasks
+
+Also accepts `PagingParameters` from query string.
+
+Returns: `ActionResult<IEnumerable<ProjectDto>>` with `X-Pagination` header.
+
+## Implementation
+
+Both endpoints use the existing `IRepository<T>` methods. No new repository code.
+
+**TrackedTask search:** Build a filter expression from query params, pass to `GetPaged` with `orderBy: StartDate desc` and `includeProperties: "Project"`.
+
+**Project search with minTaskCount:** Load user's projects with `TrackedTasks` included via `Get`, filter by name search, filter by task count in-memory, then apply pagination. User-scoped data is small enough for this approach.
+
+## Files to Modify
+
+- `Timinute/Server/Controllers/TrackedTaskController.cs` (add SearchTrackedTasks action)
+- `Timinute/Server/Controllers/ProjectController.cs` (add SearchProjects action)
+- `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs` (5 new tests)
+- `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs` (3 new tests)
+
+## Test Plan
+
+**TrackedTask search (5 tests):**
+- `Search_Tasks_By_DateRange` — only tasks within range
+- `Search_Tasks_By_ProjectId` — filter by project
+- `Search_Tasks_By_Name` — case-insensitive search
+- `Search_Tasks_Combined_Filters` — AND logic with multiple params
+- `Search_Tasks_Another_User_Empty` — user isolation
+
+**Project search (3 tests):**
+- `Search_Projects_By_Name` — case-insensitive search
+- `Search_Projects_By_MinTaskCount` — count filtering
+- `Search_Projects_Another_User_Empty` — user isolation

--- a/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
@@ -36,7 +36,7 @@ Sorted by StartDate descending. Includes Project navigation property.
 On existing `ProjectController`. `[Authorize]`.
 
 Query params (all optional, combined with AND):
-- `search` (`string?`) — case-insensitive Contains on project Name
+- `search` (`string?`) — Contains on project Name (case sensitivity depends on DB collation)
 - `minTaskCount` (`int?`) — only projects with at least N tracked tasks
 
 Also accepts `PagingParameters` from query string.
@@ -65,11 +65,11 @@ Both endpoints use the existing `IRepository<T>.GetPaged` method. No new reposit
 **TrackedTask search (5 tests):**
 - `Search_Tasks_By_DateRange` — only tasks within range
 - `Search_Tasks_By_ProjectId` — filter by project
-- `Search_Tasks_By_Name` — case-insensitive search
+- `Search_Tasks_By_Name` — name search (case sensitivity depends on DB collation)
 - `Search_Tasks_Combined_Filters` — AND logic with multiple params
 - `Search_Tasks_Another_User_Empty` — user isolation
 
 **Project search (3 tests):**
-- `Search_Projects_By_Name` — case-insensitive search
+- `Search_Projects_By_Name` — name search (case sensitivity depends on DB collation)
 - `Search_Projects_By_MinTaskCount` — count filtering
 - `Search_Projects_Another_User_Empty` — user isolation

--- a/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-01-advanced-filtering-design.md
@@ -45,11 +45,13 @@ Returns: `ActionResult<IEnumerable<ProjectDto>>` with `X-Pagination` header.
 
 ## Implementation
 
-Both endpoints use the existing `IRepository<T>` methods. No new repository code.
+Both endpoints use the existing `IRepository<T>.GetPaged` method. No new repository code.
 
 **TrackedTask search:** Build a filter expression from query params, pass to `GetPaged` with `orderBy: StartDate desc` and `includeProperties: "Project"`.
 
-**Project search with minTaskCount:** Load user's projects with `TrackedTasks` included via `Get`, filter by name search, filter by task count in-memory, then apply pagination. User-scoped data is small enough for this approach.
+**Project search with minTaskCount:** Use `GetPaged` with `p.TrackedTasks!.Count >= minTaskCount` in the filter expression — EF Core translates this to a SQL COUNT subquery. Ordered by Name.
+
+**Search case sensitivity:** `string.Contains(search)` without `StringComparison` parameter is used for EF Core translatability. Case sensitivity depends on database collation (SQL Server default `SQL_Latin1_General_CP1_CI_AS` is case-insensitive). InMemory provider in tests uses case-sensitive comparison.
 
 ## Files to Modify
 


### PR DESCRIPTION
## Summary

- Add `GET /trackedtask/search` with date range, project, and name filters
- Add `GET /project/search` with name search and minimum task count filter
- Both paginated with X-Pagination header, user-scoped

## New Endpoints

| Endpoint | Filters |
|----------|---------|
| `GET /trackedtask/search` | `from`, `to` (DateTimeOffset), `projectId`, `search` (name) |
| `GET /project/search` | `search` (name), `minTaskCount` (int) |

All filters optional, combined with AND logic. Empty/whitespace params treated as not provided. Results sorted by StartDate desc (tasks) / Name (projects).

## Implementation Notes

- TrackedTask search uses `GetPaged` with combined filter expression
- Project search uses `GetPaged` with `TrackedTasks.Count >= N` (EF translates to SQL COUNT subquery)
- `string.Contains()` without StringComparison — relies on SQL Server case-insensitive collation
- `minTaskCount` validated >= 0
- Query params normalized (empty/whitespace → null, trimmed)

## Test plan

- [x] `dotnet build Timinute.sln` — 0 errors
- [x] `dotnet test` — 68/68 passing (60 existing + 8 new)
- [x] Search by date range returns only matching tasks
- [x] Search by projectId returns only matching tasks
- [x] Search by name (case sensitivity depends on DB collation)
- [x] Combined filters use AND logic
- [x] User isolation — non-owner gets empty results
- [x] MinTaskCount filters projects correctly