### PR TITLE
Aurora-skin Identity pages (Login, Register, shared layout)

### DIFF
--- a/Timinute/Server/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Timinute/Server/Areas/Identity/Pages/Account/Login.cshtml
@@ -1,83 +1,60 @@
-﻿@page
+@page
 @model LoginModel
 
 @{
     ViewData["Title"] = "Log in";
 }
 
-<h1>@ViewData["Title"]</h1>
-<div class="row">
-    <div class="col-md-4">
-        <section>
-            <form id="account" method="post">
-                <h2>Use a local account to log in.</h2>
-                <hr />
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <div class="form-floating mb-3">
-                    <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
-                    <label asp-for="Input.Email" class="form-label"></label>
-                    <span asp-validation-for="Input.Email" class="text-danger"></span>
-                </div>
-                <div class="form-floating mb-3">
-                    <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
-                    <label asp-for="Input.Password" class="form-label"></label>
-                    <span asp-validation-for="Input.Password" class="text-danger"></span>
-                </div>
-                <div>
-                    <div class="checkbox">
-                        <label asp-for="Input.RememberMe" class="form-label">
-                            <input class="form-check-input" asp-for="Input.RememberMe" />
-                            @Html.DisplayNameFor(m => m.Input.RememberMe)
-                        </label>
-                    </div>
-                </div>
-                <div>
-                    <button id="login-submit" type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-                </div>
-                <div>
-                    <p>
-                        <a id="forgot-password" asp-page="./ForgotPassword">Forgot your password?</a>
-                    </p>
-                    <p>
-                        <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Register as a new user</a>
-                    </p>
-                    <p>
-                        <a id="resend-confirmation" asp-page="./ResendEmailConfirmation">Resend email confirmation</a>
-                    </p>
-                </div>
+<div class="aurora-id-card">
+    <h1 class="aurora-id-card__title">Welcome back</h1>
+    <p class="aurora-id-card__sub">Log in to keep tracking your minutes.</p>
+
+    <form id="account" method="post">
+        <div asp-validation-summary="ModelOnly" class="validation-summary-errors"></div>
+
+        <div class="form-floating">
+            <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder=" " />
+            <label asp-for="Input.Email" class="form-label">Email</label>
+            <span asp-validation-for="Input.Email" class="text-danger"></span>
+        </div>
+
+        <div class="form-floating">
+            <input asp-for="Input.Password" type="password" class="form-control" autocomplete="current-password" aria-required="true" placeholder=" " />
+            <label asp-for="Input.Password" class="form-label">Password</label>
+            <span asp-validation-for="Input.Password" class="text-danger"></span>
+        </div>
+
+        <div class="aurora-id-card__row">
+            <label class="checkbox" for="@Html.IdFor(m => m.Input.RememberMe)">
+                <input class="form-check-input" asp-for="Input.RememberMe" />
+                @Html.DisplayNameFor(m => m.Input.RememberMe)
+            </label>
+            <a id="forgot-password" asp-page="./ForgotPassword">Forgot password?</a>
+        </div>
+
+        <button id="login-submit" type="submit" class="aurora-id-submit">Log in</button>
+
+        <div class="aurora-id-card__row aurora-id-card__row--center">
+            Don't have an account? <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl" style="margin-left: 6px;">Sign up</a>
+        </div>
+
+        <div class="aurora-id-card__row aurora-id-card__row--center" style="margin-top: 8px; font-size: 12px;">
+            <a id="resend-confirmation" asp-page="./ResendEmailConfirmation">Resend email confirmation</a>
+        </div>
+    </form>
+
+    @if ((Model.ExternalLogins?.Count ?? 0) > 0)
+    {
+        <div class="aurora-id-card__external">
+            <div class="aurora-id-card__external-label">Or continue with</div>
+            <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+                @foreach (var provider in Model.ExternalLogins)
+                {
+                    <button type="submit" class="btn" name="provider" value="@provider.Name" title="Log in with @provider.DisplayName">@provider.DisplayName</button>
+                }
             </form>
-        </section>
-    </div>
-    <div class="col-md-6 col-md-offset-2">
-        <section>
-            <h3>Use another service to log in.</h3>
-            <hr />
-            @{
-                if ((Model.ExternalLogins?.Count ?? 0) == 0)
-                {
-                    <div>
-                        <p>
-                            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">article
-                            about setting up this ASP.NET application to support logging in via external services</a>.
-                        </p>
-                    </div>
-                }
-                else
-                {
-                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
-                        <div>
-                            <p>
-                                @foreach (var provider in Model.ExternalLogins)
-                                {
-                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                                }
-                            </p>
-                        </div>
-                    </form>
-                }
-            }
-        </section>
-    </div>
+        </div>
+    }
 </div>
 
 @section Scripts {

--- a/Timinute/Server/Areas/Identity/Pages/Account/Register.cshtml
+++ b/Timinute/Server/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,79 +1,67 @@
-﻿@page
+@page
 @model RegisterModel
 @{
     ViewData["Title"] = "Register";
 }
 
-<h1>@ViewData["Title"]</h1>
+<div class="aurora-id-card">
+    <h1 class="aurora-id-card__title">Create your account</h1>
+    <p class="aurora-id-card__sub">Free forever. Self-host ready. No credit card.</p>
 
-<div class="row">
-    <div class="col-md-4">
-        <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
-            <h2>Create a new account.</h2>
-            <hr />
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
-                <label asp-for="Input.Email"></label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.FirstName" class="form-control" autocomplete="FirstName" aria-required="true" />
-                <label asp-for="Input.FirstName"></label>
-                <span asp-validation-for="Input.FirstName" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.LastName" class="form-control" autocomplete="LastName" aria-required="true" />
-                <label asp-for="Input.LastName"></label>
-                <span asp-validation-for="Input.LastName" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
-                <label asp-for="Input.Password"></label>
-                <span asp-validation-for="Input.Password" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
-                <label asp-for="Input.ConfirmPassword"></label>
-                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
-            </div>
-            <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
-        </form>
-    </div>
-    <div class="col-md-6 col-md-offset-2">
-        <section>
-            <h3>Use another service to register.</h3>
-            <hr />
-            @{
-                if ((Model.ExternalLogins?.Count ?? 0) == 0)
+    <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+        <div asp-validation-summary="ModelOnly" class="validation-summary-errors"></div>
+
+        <div class="form-floating">
+            <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder=" " />
+            <label asp-for="Input.Email">Email</label>
+            <span asp-validation-for="Input.Email" class="text-danger"></span>
+        </div>
+
+        <div class="form-floating">
+            <input asp-for="Input.FirstName" class="form-control" autocomplete="given-name" aria-required="true" placeholder=" " />
+            <label asp-for="Input.FirstName">First name</label>
+            <span asp-validation-for="Input.FirstName" class="text-danger"></span>
+        </div>
+
+        <div class="form-floating">
+            <input asp-for="Input.LastName" class="form-control" autocomplete="family-name" aria-required="true" placeholder=" " />
+            <label asp-for="Input.LastName">Last name</label>
+            <span asp-validation-for="Input.LastName" class="text-danger"></span>
+        </div>
+
+        <div class="form-floating">
+            <input asp-for="Input.Password" type="password" class="form-control" autocomplete="new-password" aria-required="true" placeholder=" " />
+            <label asp-for="Input.Password">Password</label>
+            <span asp-validation-for="Input.Password" class="text-danger"></span>
+        </div>
+
+        <div class="form-floating">
+            <input asp-for="Input.ConfirmPassword" type="password" class="form-control" autocomplete="new-password" aria-required="true" placeholder=" " />
+            <label asp-for="Input.ConfirmPassword">Confirm password</label>
+            <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+        </div>
+
+        <button id="registerSubmit" type="submit" class="aurora-id-submit">Get started — free</button>
+
+        <div class="aurora-id-card__row aurora-id-card__row--center">
+            Already have an account? <a asp-page="./Login" style="margin-left: 6px;">Log in</a>
+        </div>
+    </form>
+
+    @if ((Model.ExternalLogins?.Count ?? 0) > 0)
+    {
+        <div class="aurora-id-card__external">
+            <div class="aurora-id-card__external-label">Or sign up with</div>
+            <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+                @foreach (var provider in Model.ExternalLogins)
                 {
-                    <div>
-                        <p>
-                            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">
-                                article
-                                about setting up this ASP.NET application to support logging in via external services
-                            </a>.
-                        </p>
-                    </div>
+                    <button type="submit" class="btn" name="provider" value="@provider.Name" title="Sign up with @provider.DisplayName">@provider.DisplayName</button>
                 }
-                else
-                {
-                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
-                        <div>
-                            <p>
-                                @foreach (var provider in Model.ExternalLogins)
-                                {
-                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                                }
-                            </p>
-                        </div>
-                    </form>
-                }
-            }
-        </section>
-    </div>
+            </form>
+        </div>
+    }
 </div>
 
 @section Scripts {
-<partial name="_ValidationScriptsPartial" />
+    <partial name="_ValidationScriptsPartial" />
 }

--- a/Timinute/Server/Pages/Shared/_Layout.cshtml
+++ b/Timinute/Server/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.AspNetCore.Hosting
+@using Microsoft.AspNetCore.Hosting
 @using Microsoft.AspNetCore.Mvc.ViewEngines
 @inject IWebHostEnvironment Environment
 @inject ICompositeViewEngine Engine
@@ -7,65 +7,52 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - Timinute Account</title>
+    <title>@ViewData["Title"] — Timinute</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@@400;500;600;700&display=swap" rel="stylesheet" />
 
     <environment include="Development">
         <link rel="stylesheet" href="~/Identity/lib/bootstrap/dist/css/bootstrap.css" />
         <link rel="stylesheet" href="~/Identity/css/site.css" />
     </environment>
     <environment exclude="Development">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css"
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@@5.1.0/dist/css/bootstrap.min.css"
               integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous"
               asp-fallback-href="~/Identity/lib/bootstrap/dist/css/bootstrap.min.css"
               asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
         <link rel="stylesheet" href="~/Identity/css/site.css" asp-append-version="true" />
     </environment>
+    <link rel="stylesheet" href="~/Identity/css/aurora-identity.css" asp-append-version="true" />
 </head>
 <body>
-    <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
-            <div class="container">
-                <a class="navbar-brand" href="~/">Timinute Account</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
-                    @{
-                        var result = Engine.FindView(ViewContext, "_LoginPartial", isMainPage: false);
-                    }
-                    @if (result.Success)
-                    {
-                        await Html.RenderPartialAsync("_LoginPartial");
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("The default Identity UI layout requires a partial view '_LoginPartial' " +
-                            "usually located at '/Pages/_LoginPartial' or at '/Views/Shared/_LoginPartial' to work. Based on your configuration " +
-                            $"we have looked at it in the following locations: {System.Environment.NewLine}{string.Join(System.Environment.NewLine, result.SearchedLocations)}.");
-                    }
-                </div>
-            </div>
-        </nav>
+    <header class="aurora-id-top">
+        <a class="aurora-id-brand" href="~/">
+            <span class="aurora-id-brand__mark" aria-hidden="true">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="13" r="7.5" />
+                    <path d="M12 9v4l2.5 2" />
+                </svg>
+            </span>
+            <span class="aurora-id-brand__text">timinute<span class="aurora-id-brand__dot">.</span></span>
+        </a>
     </header>
 
-    <div class="container">
+    <main role="main" class="aurora-id-shell">
         <partial name="_CookieConsentPartial" optional />
-        <main role="main" class="pb-1">
-            @RenderBody()
-        </main>
-    </div>
-    <footer class="footer border-top pl-3 text-muted">
-        <div class="container">
-        &copy; 2021 - Timinute
-            @{
-                var foundPrivacy = Url.Page("/Privacy", new { area = "" });
-            }
-            @if (foundPrivacy != null)
-            {
-                <a asp-area="" asp-page="/Privacy">Privacy</a>
-            }
-        </div>
+        @RenderBody()
+    </main>
+
+    <footer class="aurora-id-footer">
+        © @DateTime.UtcNow.Year Timinute
+        @{
+            var foundPrivacy = Url.Page("/Privacy", new { area = "" });
+        }
+        @if (foundPrivacy != null)
+        {
+            <span> · <a asp-area="" asp-page="/Privacy">Privacy</a></span>
+        }
     </footer>
 
     <environment include="Development">
@@ -80,7 +67,7 @@
                 crossorigin="anonymous"
                 integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2">
         </script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@@5.1.0/dist/js/bootstrap.bundle.min.js"
                 asp-fallback-src="~/Identity/lib/bootstrap/dist/js/bootstrap.bundle.min.js"
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
                 crossorigin="anonymous"

--- a/Timinute/Server/Pages/Shared/_Layout.cshtml
+++ b/Timinute/Server/Pages/Shared/_Layout.cshtml
@@ -39,8 +39,9 @@
         </a>
     </header>
 
+    <partial name="_CookieConsentPartial" optional />
+
     <main role="main" class="aurora-id-shell">
-        <partial name="_CookieConsentPartial" optional />
         @RenderBody()
     </main>
 

--- a/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
+++ b/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
@@ -1,6 +1,11 @@
 /* Aurora overlay for Identity Razor Pages — Login, Register, password flows.
    Loads after Bootstrap so its overrides win. Uses literal hex values because
-   these pages don't share aurora.css from the WASM client. */
+   these pages don't share aurora.css from the WASM client.
+
+   Form/button overrides are scoped to .aurora-id-shell (not .aurora-id-card)
+   so the cascade also picks up Manage pages, ConfirmEmail, ForgotPassword,
+   etc. — every Identity page renders inside .aurora-id-shell, but only
+   Login/Register currently wrap their content in .aurora-id-card. */
 
 :root {
     --bg: #F5F2EC;
@@ -65,9 +70,18 @@ html, body {
     color: var(--accent);
 }
 
-/* Page container — centered card */
+/* Page container — Login/Register get a centered card; other Identity pages
+   (Manage, password flows, etc.) get a top-aligned padded layout. The :has()
+   query gives us the conditional centering without two layout components. */
 .aurora-id-shell {
     min-height: calc(100vh - 240px);
+    padding: 40px 24px;
+    max-width: 1100px;
+    margin: 0 auto;
+    box-sizing: border-box;
+}
+
+.aurora-id-shell:has(> .aurora-id-card) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -121,13 +135,14 @@ html, body {
     color: var(--text);
 }
 
-/* --- Bootstrap form overrides --- */
+/* --- Bootstrap form overrides — shell-scoped so Manage/forgot-password/etc.
+       inherit the Aurora form look even though their bodies aren't card-wrapped. */
 
-.aurora-id-card .form-floating {
+.aurora-id-shell .form-floating {
     margin-bottom: 14px;
 }
 
-.aurora-id-card .form-control {
+.aurora-id-shell .form-control {
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 10px;
@@ -138,41 +153,60 @@ html, body {
     transition: border-color .15s ease, box-shadow .15s ease;
 }
 
-.aurora-id-card .form-control:focus {
+.aurora-id-shell .form-control:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 3px var(--accent-so);
     outline: none;
 }
 
-.aurora-id-card .form-floating > label {
+.aurora-id-shell .form-floating > label {
     color: var(--text-mu);
     padding: 16px 14px;
 }
 
-.aurora-id-card .form-floating > .form-control:focus ~ label,
-.aurora-id-card .form-floating > .form-control:not(:placeholder-shown) ~ label {
+.aurora-id-shell .form-floating > .form-control:focus ~ label,
+.aurora-id-shell .form-floating > .form-control:not(:placeholder-shown) ~ label {
+    color: var(--accent-ink);
+    transform: scale(.78) translateY(-0.7rem) translateX(0.1rem);
+    background: transparent;
+}
+
+/* Chrome/Edge :-webkit-autofill: password managers fill the value via JS,
+   :not(:placeholder-shown) evaluates true correctly, but the autofill yellow
+   tint and white-on-white text fight the floating label. Force the label to
+   stay raised and neutralize the autofill background. */
+.aurora-id-shell .form-control:-webkit-autofill,
+.aurora-id-shell .form-control:-webkit-autofill:hover,
+.aurora-id-shell .form-control:-webkit-autofill:focus {
+    -webkit-text-fill-color: var(--text);
+    -webkit-box-shadow: 0 0 0 1000px var(--surface) inset;
+    transition: background-color 5000s ease-in-out 0s;
+    caret-color: var(--text);
+}
+
+.aurora-id-shell .form-floating > .form-control:-webkit-autofill ~ label {
     color: var(--accent-ink);
     transform: scale(.78) translateY(-0.7rem) translateX(0.1rem);
     background: transparent;
 }
 
 /* Validation messages */
-.aurora-id-card .text-danger,
-.aurora-id-card .field-validation-error,
-.aurora-id-card .validation-summary-errors {
+.aurora-id-shell .text-danger,
+.aurora-id-shell .field-validation-error,
+.aurora-id-shell .validation-summary-errors {
     color: var(--danger);
     font-size: 12.5px;
     margin-top: 4px;
     display: block;
 }
 
-.aurora-id-card .validation-summary-errors ul {
+.aurora-id-shell .validation-summary-errors ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.aurora-id-card .validation-summary-errors:not(:empty) {
+.aurora-id-shell .validation-summary-errors:not(:empty) {
     background: color-mix(in srgb, #EF4444 8%, transparent);
     border: 1px solid color-mix(in srgb, #EF4444 30%, transparent);
     border-radius: 10px;
@@ -181,9 +215,9 @@ html, body {
 }
 
 /* Submit button — Aurora primary */
-.aurora-id-card .btn-primary,
-.aurora-id-card button[type="submit"].btn,
-.aurora-id-card .aurora-id-submit {
+.aurora-id-shell .btn-primary,
+.aurora-id-shell button[type="submit"].btn,
+.aurora-id-shell .aurora-id-submit {
     background: var(--accent);
     border: none;
     color: #fff;
@@ -196,21 +230,21 @@ html, body {
     transition: background .15s ease, transform .08s ease;
 }
 
-.aurora-id-card .btn-primary:hover,
-.aurora-id-card button[type="submit"].btn:hover,
-.aurora-id-card .aurora-id-submit:hover {
+.aurora-id-shell .btn-primary:hover,
+.aurora-id-shell button[type="submit"].btn:hover,
+.aurora-id-shell .aurora-id-submit:hover {
     background: var(--accent-ink);
     color: #fff;
 }
 
-.aurora-id-card .btn-primary:active,
-.aurora-id-card button[type="submit"].btn:active,
-.aurora-id-card .aurora-id-submit:active {
+.aurora-id-shell .btn-primary:active,
+.aurora-id-shell button[type="submit"].btn:active,
+.aurora-id-shell .aurora-id-submit:active {
     transform: scale(.98);
 }
 
 /* Remember-me checkbox row */
-.aurora-id-card .form-check {
+.aurora-id-shell .form-check {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -219,7 +253,7 @@ html, body {
     color: var(--text-mu);
 }
 
-.aurora-id-card .form-check-input {
+.aurora-id-shell .form-check-input {
     width: 16px;
     height: 16px;
     border: 1px solid var(--border);
@@ -228,7 +262,7 @@ html, body {
     margin: 0;
 }
 
-.aurora-id-card .checkbox label {
+.aurora-id-shell .checkbox label {
     display: inline-flex;
     align-items: center;
     gap: 8px;

--- a/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
+++ b/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
@@ -1,0 +1,320 @@
+/* Aurora overlay for Identity Razor Pages — Login, Register, password flows.
+   Loads after Bootstrap so its overrides win. Uses literal hex values because
+   these pages don't share aurora.css from the WASM client. */
+
+:root {
+    --bg: #F5F2EC;
+    --surface: #FFFFFF;
+    --surface-2: #FAF7F0;
+    --text: #1A1A24;
+    --text-mu: #6B6878;
+    --text-dim: #9B97A8;
+    --border: #E8E2D5;
+    --accent: #5B5BF5;
+    --accent-so: #EEEDFF;
+    --accent-ink: #3838C7;
+    --danger: #EF4444;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    color: var(--text);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* Top bar — minimal, just the wordmark */
+.aurora-id-top {
+    padding: 24px 48px;
+    max-width: 1280px;
+    margin: 0 auto;
+}
+
+.aurora-id-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    text-decoration: none;
+}
+
+.aurora-id-brand:hover {
+    text-decoration: none;
+}
+
+.aurora-id-brand__mark {
+    width: 30px;
+    height: 30px;
+    border-radius: 9px;
+    background: linear-gradient(135deg, #5B5BF5, #9D7CFF);
+    box-shadow: 0 4px 14px rgba(91, 91, 245, .4);
+    display: grid;
+    place-items: center;
+}
+
+.aurora-id-brand__text {
+    font-weight: 600;
+    font-size: 18px;
+    letter-spacing: -0.4px;
+    color: var(--text);
+}
+
+.aurora-id-brand__dot {
+    color: var(--accent);
+}
+
+/* Page container — centered card */
+.aurora-id-shell {
+    min-height: calc(100vh - 240px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.aurora-id-card {
+    width: 100%;
+    max-width: 440px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 36px 32px;
+    box-shadow: 0 1px 0 var(--border), 0 30px 60px -25px rgba(20, 18, 40, .12);
+}
+
+.aurora-id-card__title {
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: -0.7px;
+    color: var(--text);
+    margin: 0;
+}
+
+.aurora-id-card__sub {
+    margin: 6px 0 28px;
+    font-size: 14px;
+    color: var(--text-mu);
+}
+
+.aurora-id-card__divider {
+    border: 0;
+    border-top: 1px solid var(--border);
+    margin: 24px 0;
+}
+
+/* Footer */
+.aurora-id-footer {
+    text-align: center;
+    padding: 24px 48px 40px;
+    font-size: 13px;
+    color: var(--text-mu);
+}
+
+.aurora-id-footer a {
+    color: var(--text-mu);
+    text-decoration: none;
+}
+
+.aurora-id-footer a:hover {
+    color: var(--text);
+}
+
+/* --- Bootstrap form overrides --- */
+
+.aurora-id-card .form-floating {
+    margin-bottom: 14px;
+}
+
+.aurora-id-card .form-control {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    color: var(--text);
+    height: 52px;
+    padding: 16px 14px 4px;
+    font-size: 14px;
+    transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.aurora-id-card .form-control:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-so);
+    outline: none;
+}
+
+.aurora-id-card .form-floating > label {
+    color: var(--text-mu);
+    padding: 16px 14px;
+}
+
+.aurora-id-card .form-floating > .form-control:focus ~ label,
+.aurora-id-card .form-floating > .form-control:not(:placeholder-shown) ~ label {
+    color: var(--accent-ink);
+    transform: scale(.78) translateY(-0.7rem) translateX(0.1rem);
+    background: transparent;
+}
+
+/* Validation messages */
+.aurora-id-card .text-danger,
+.aurora-id-card .field-validation-error,
+.aurora-id-card .validation-summary-errors {
+    color: var(--danger);
+    font-size: 12.5px;
+    margin-top: 4px;
+    display: block;
+}
+
+.aurora-id-card .validation-summary-errors ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.aurora-id-card .validation-summary-errors:not(:empty) {
+    background: color-mix(in srgb, #EF4444 8%, transparent);
+    border: 1px solid color-mix(in srgb, #EF4444 30%, transparent);
+    border-radius: 10px;
+    padding: 12px 14px;
+    margin-bottom: 16px;
+}
+
+/* Submit button — Aurora primary */
+.aurora-id-card .btn-primary,
+.aurora-id-card button[type="submit"].btn,
+.aurora-id-card .aurora-id-submit {
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    border-radius: 12px;
+    padding: 13px 18px;
+    font: 500 15px 'Geist', sans-serif;
+    width: 100%;
+    height: auto;
+    box-shadow: 0 12px 32px -10px rgba(91, 91, 245, .55);
+    transition: background .15s ease, transform .08s ease;
+}
+
+.aurora-id-card .btn-primary:hover,
+.aurora-id-card button[type="submit"].btn:hover,
+.aurora-id-card .aurora-id-submit:hover {
+    background: var(--accent-ink);
+    color: #fff;
+}
+
+.aurora-id-card .btn-primary:active,
+.aurora-id-card button[type="submit"].btn:active,
+.aurora-id-card .aurora-id-submit:active {
+    transform: scale(.98);
+}
+
+/* Remember-me checkbox row */
+.aurora-id-card .form-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0 18px;
+    font-size: 13px;
+    color: var(--text-mu);
+}
+
+.aurora-id-card .form-check-input {
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    accent-color: var(--accent);
+    margin: 0;
+}
+
+.aurora-id-card .checkbox label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    color: var(--text);
+    font-weight: 400;
+    cursor: pointer;
+}
+
+/* Inline links inside the card */
+.aurora-id-card a {
+    color: var(--accent-ink);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color .15s ease;
+}
+
+.aurora-id-card a:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.aurora-id-card__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 8px;
+    font-size: 13px;
+}
+
+.aurora-id-card__row--center {
+    justify-content: center;
+    margin-top: 18px;
+    color: var(--text-mu);
+}
+
+/* External providers section (if any are configured) */
+.aurora-id-card__external {
+    margin-top: 24px;
+}
+
+.aurora-id-card__external-label {
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    position: relative;
+    margin: 24px 0 18px;
+}
+
+.aurora-id-card__external-label::before,
+.aurora-id-card__external-label::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: calc(50% - 60px);
+    height: 1px;
+    background: var(--border);
+}
+
+.aurora-id-card__external-label::before { left: 0; }
+.aurora-id-card__external-label::after  { right: 0; }
+
+.aurora-id-card__external .btn {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 14px;
+    font: 500 14px 'Geist', sans-serif;
+    margin: 4px 4px 0 0;
+    box-shadow: none;
+}
+
+.aurora-id-card__external .btn:hover {
+    background: var(--surface);
+    color: var(--text);
+}
+
+@media (max-width: 600px) {
+    .aurora-id-top {
+        padding: 20px 24px;
+    }
+
+    .aurora-id-card {
+        padding: 28px 24px;
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Aurora visual loop — Identity Razor Pages are no longer the lone Bootstrap holdouts.

**Three files changed:**
- \`Server/Pages/Shared/_Layout.cshtml\` — Geist fonts, wordmark top bar, centered card shell, minimal footer.
- \`Server/wwwroot/Identity/css/aurora-identity.css\` (new) — Aurora overlay for Bootstrap form classes (form-floating, form-control, btn-primary). Loads after Bootstrap so its overrides win.
- \`Server/Areas/Identity/Pages/Account/Login.cshtml\` + \`Register.cshtml\` — Aurora-styled card layout with friendlier headers, primary button, footer cross-links, external-providers section that only renders when something's configured.

## What's not in scope

- Other Identity pages (forgot password, lockout, manage profile, etc.) inherit the new layout — they look better on the Aurora background but their forms are unchanged. Easy follow-up if any specific page warrants attention.
- Server-side validation summary styling reuses the existing \`text-danger\` Bootstrap class plus an Aurora soft-red panel for the \`validation-summary-errors\` wrapper.

## Test plan

- [ ] \`dotnet build Timinute.sln\` — succeeds
- [ ] \`dotnet test Timinute.sln\` — 94 tests pass
- [ ] Sign out, click "Log in" on landing → see Aurora-themed Login card with floating labels, indigo focus rings, primary "Log in" button
- [ ] Click "Sign up" link → routes to Register, same card style, "Get started — free" button
- [ ] Forgot password / Resend confirmation links still work
- [ ] Submit invalid form → validation summary renders inside a red-tinted box with rounded corners
- [ ] Submit valid registration → redirects to RegisterConfirmation page (inherits new layout, body unchanged)
- [ ] Mobile viewport (≤600px): card padding tightens, wordmark stays in nav