### PR TITLE
Aurora mobile responsive treatment

### DIFF
--- a/Timinute/Client/Components/Dashboard/Dashboard.razor.css
+++ b/Timinute/Client/Components/Dashboard/Dashboard.razor.css
@@ -279,3 +279,65 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* Mobile reflow: tighter padding, hero number shrinks, stat cards 2-up,
+   chart card heights reduce. Recent activity row drops the desktop-only
+   columns into a stacked layout. */
+@media (max-width: 768px) {
+    .aurora-dashboard {
+        padding: 12px 16px 16px;
+        gap: 14px;
+    }
+
+    .aurora-dashboard__hero-row {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 10px;
+    }
+
+    .aurora-hero-card {
+        grid-column: 1 / -1;
+        padding: 22px;
+        border-radius: 22px;
+    }
+
+    .aurora-hero-card__big {
+        font-size: 46px;
+        letter-spacing: -2px;
+    }
+
+    .aurora-hero-card__unit {
+        font-size: 22px;
+    }
+
+    .aurora-stat-card__big {
+        font-size: 26px;
+        letter-spacing: -1px;
+    }
+
+    .aurora-stat-card__unit {
+        font-size: 16px;
+    }
+
+    .aurora-activity__row {
+        grid-template-columns: 14px 1fr 80px;
+        row-gap: 4px;
+        padding: 12px 14px;
+    }
+
+    .aurora-activity__time,
+    .aurora-activity__more {
+        display: none;
+    }
+
+    .aurora-activity__duration {
+        font-size: 13px;
+    }
+
+    .aurora-chart-header__title {
+        font-size: 14px;
+    }
+
+    .aurora-chart-header__sub {
+        font-size: 12.5px;
+    }
+}

--- a/Timinute/Client/Components/Scheduler/DayCalendar.razor
+++ b/Timinute/Client/Components/Scheduler/DayCalendar.razor
@@ -45,6 +45,8 @@
             var daysFromMonday = ((int)SelectedDay.DayOfWeek + 6) % 7; // Mon=0..Sun=6
             SelectedDay = WeekStart.AddDays(daysFromMonday);
         }
+
+        RebuildSelectedDay();
     }
 
     public void Dispose()
@@ -57,13 +59,25 @@
         }
     }
 
-    private List<TrackedTaskDto> SelectedDayTasks =>
-        Tasks.Where(t => t.StartDate.LocalDateTime.Date == SelectedDay.Date)
-             .OrderBy(t => t.StartDate)
-             .ToList();
+    // Cached per parameter set + on selection change so the markup can reference
+    // it multiple times without re-allocating/re-sorting on each access.
+    private List<TrackedTaskDto> selectedDayTasks = new();
+    private double selectedDayHours;
 
-    private double SelectedDayHours =>
-        SelectedDayTasks.Sum(t => t.Duration.TotalHours);
+    private void RebuildSelectedDay()
+    {
+        selectedDayTasks = Tasks
+            .Where(t => t.StartDate.LocalDateTime.Date == SelectedDay.Date)
+            .OrderBy(t => t.StartDate)
+            .ToList();
+        selectedDayHours = selectedDayTasks.Sum(t => t.Duration.TotalHours);
+    }
+
+    private void SelectDay(DateTime day)
+    {
+        SelectedDay = day;
+        RebuildSelectedDay();
+    }
 
     private bool SelectedIsToday => SelectedDay.Date == DateTime.Today;
 
@@ -118,7 +132,7 @@
             var isSelected = d.Date == SelectedDay.Date;
             <button type="button"
                     class="dcal__strip-day @(isSelected ? "is-selected" : "")"
-                    @onclick="() => SelectedDay = d.Date">
+                    @onclick="() => SelectDay(d.Date)">
                 <span class="dcal__strip-eyebrow">@d.ToString("ddd", System.Globalization.CultureInfo.InvariantCulture).ToUpperInvariant()</span>
                 <span class="dcal__strip-num">@d.Day</span>
             </button>
@@ -129,7 +143,7 @@
     <div class="dcal__header">
         <div class="dcal__header-meta">
             <div class="dcal__header-label">@SelectedDayLabel</div>
-            <div class="dcal__header-sub">@SelectedDayTasks.Count task@(SelectedDayTasks.Count == 1 ? "" : "s") · @SelectedDayHours.ToString("0.#")h</div>
+            <div class="dcal__header-sub">@selectedDayTasks.Count task@(selectedDayTasks.Count == 1 ? "" : "s") · @selectedDayHours.ToString("0.#")h</div>
         </div>
         <div class="dcal__segmented">
             <button class="dcal__segmented-btn is-active" type="button">Day</button>
@@ -165,7 +179,7 @@
                 </div>
             }
 
-            @foreach (var t in SelectedDayTasks)
+            @foreach (var t in selectedDayTasks)
             {
                 var (top, height) = PositionFor(t);
                 var color = ColorService.GetColor(t.Project);

--- a/Timinute/Client/Components/Scheduler/DayCalendar.razor
+++ b/Timinute/Client/Components/Scheduler/DayCalendar.razor
@@ -1,0 +1,176 @@
+@using Timinute.Shared.Dtos.TrackedTask
+@implements IDisposable
+@inject Timinute.Client.Services.ProjectColorService ColorService
+
+@code {
+    [Parameter] public DateTime WeekStart { get; set; }
+    [Parameter] public IList<TrackedTaskDto> Tasks { get; set; } = new List<TrackedTaskDto>();
+    [Parameter] public EventCallback<DateTime> OnEmptyClick { get; set; }
+    [Parameter] public EventCallback<TrackedTaskDto> OnEventClick { get; set; }
+
+    private System.Timers.Timer? nowTimer;
+    private DateTime SelectedDay;
+
+    private const int RowHeight = 52;
+    private const int FirstHour = 8;
+    private const int LastHour = 18;
+    private const int Slots = LastHour - FirstHour + 1;
+
+    private DateTime[] DayDates =>
+        Enumerable.Range(0, 7).Select(i => WeekStart.AddDays(i)).ToArray();
+
+    protected override void OnInitialized()
+    {
+        nowTimer = new System.Timers.Timer(60_000) { AutoReset = true };
+        nowTimer.Elapsed += async (_, _) => await InvokeAsync(StateHasChanged);
+        nowTimer.Start();
+    }
+
+    protected override void OnParametersSet()
+    {
+        // If the host hands us a new week, default the selection to today when in range,
+        // otherwise the first day of that week.
+        if (SelectedDay == default || SelectedDay < WeekStart || SelectedDay >= WeekStart.AddDays(7))
+        {
+            SelectedDay = (DateTime.Today >= WeekStart && DateTime.Today < WeekStart.AddDays(7))
+                ? DateTime.Today
+                : WeekStart;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (nowTimer is not null)
+        {
+            nowTimer.Stop();
+            nowTimer.Dispose();
+            nowTimer = null;
+        }
+    }
+
+    private List<TrackedTaskDto> SelectedDayTasks =>
+        Tasks.Where(t => t.StartDate.LocalDateTime.Date == SelectedDay.Date)
+             .OrderBy(t => t.StartDate)
+             .ToList();
+
+    private double SelectedDayHours =>
+        SelectedDayTasks.Sum(t => t.Duration.TotalHours);
+
+    private bool SelectedIsToday => SelectedDay.Date == DateTime.Today;
+
+    private double NowOffsetPx
+    {
+        get
+        {
+            var now = DateTime.Now;
+            var hourOffset = (now.Hour - FirstHour) + (now.Minute / 60.0);
+            return System.Math.Clamp(hourOffset * RowHeight, 0, Slots * RowHeight);
+        }
+    }
+
+    private (double topPx, double heightPx) PositionFor(TrackedTaskDto t)
+    {
+        var start = t.StartDate.LocalDateTime;
+        var end = (t.EndDate ?? t.StartDate + t.Duration).LocalDateTime;
+
+        var startHour = (start.Hour - FirstHour) + (start.Minute / 60.0);
+        var hours = (end - start).TotalHours;
+
+        var topClamped = System.Math.Max(0, startHour * RowHeight);
+        var endClamped = System.Math.Min(Slots * RowHeight, (startHour + hours) * RowHeight);
+        var height = System.Math.Max(28, endClamped - topClamped);
+
+        return (topClamped, height);
+    }
+
+    private string FormatRange(TrackedTaskDto t)
+    {
+        var end = (t.EndDate ?? t.StartDate + t.Duration).LocalDateTime;
+        return $"{t.StartDate.LocalDateTime:HH:mm} → {end:HH:mm}";
+    }
+
+    private string SelectedDayLabel
+    {
+        get
+        {
+            if (SelectedDay.Date == DateTime.Today) return $"Today, {SelectedDay:MMM d}";
+            if (SelectedDay.Date == DateTime.Today.AddDays(-1)) return $"Yesterday, {SelectedDay:MMM d}";
+            if (SelectedDay.Date == DateTime.Today.AddDays(1)) return $"Tomorrow, {SelectedDay:MMM d}";
+            return SelectedDay.ToString("dddd, MMM d", System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+}
+
+<div class="dcal">
+    <!-- Week strip -->
+    <div class="dcal__strip">
+        @foreach (var d in DayDates)
+        {
+            var isSelected = d.Date == SelectedDay.Date;
+            <button type="button"
+                    class="dcal__strip-day @(isSelected ? "is-selected" : "")"
+                    @onclick="() => SelectedDay = d.Date">
+                <span class="dcal__strip-eyebrow">@d.ToString("ddd", System.Globalization.CultureInfo.InvariantCulture).ToUpperInvariant()</span>
+                <span class="dcal__strip-num">@d.Day</span>
+            </button>
+        }
+    </div>
+
+    <!-- Day header -->
+    <div class="dcal__header">
+        <div class="dcal__header-meta">
+            <div class="dcal__header-label">@SelectedDayLabel</div>
+            <div class="dcal__header-sub">@SelectedDayTasks.Count task@(SelectedDayTasks.Count == 1 ? "" : "s") · @SelectedDayHours.ToString("0.#")h</div>
+        </div>
+        <div class="dcal__segmented">
+            <button class="dcal__segmented-btn is-active" type="button">Day</button>
+            <button class="dcal__segmented-btn" type="button" disabled title="Coming soon">Week</button>
+            <button class="dcal__segmented-btn" type="button" disabled title="Coming soon">Month</button>
+        </div>
+    </div>
+
+    <!-- Day grid -->
+    <div class="dcal__grid" style="height: @(Slots * RowHeight)px;">
+        <!-- Hours column -->
+        <div class="dcal__hours">
+            @for (int i = 0; i < Slots; i++)
+            {
+                var hour = FirstHour + i;
+                <div class="dcal__hour" style="height: @(RowHeight)px;">@($"{hour}:00")</div>
+            }
+        </div>
+
+        <!-- Events column -->
+        <div class="dcal__events">
+            @for (int i = 0; i < Slots; i++)
+            {
+                var hour = FirstHour + i;
+                <div class="dcal__cell" style="height: @(RowHeight)px;"
+                     @onclick="() => OnEmptyClick.InvokeAsync(SelectedDay.Date.AddHours(hour))"></div>
+            }
+
+            @if (SelectedIsToday)
+            {
+                <div class="dcal__now-line" style="top: @(NowOffsetPx.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture))px;">
+                    <div class="dcal__now-dot"></div>
+                </div>
+            }
+
+            @foreach (var t in SelectedDayTasks)
+            {
+                var (top, height) = PositionFor(t);
+                var color = ColorService.GetColor(t.Project);
+                var style = $"top: {top.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)}px; " +
+                            $"height: {height.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)}px; " +
+                            $"background: color-mix(in srgb, {color} 13%, transparent); " +
+                            $"border-left: 3px solid {color};";
+                <div class="dcal__event" style="@style"
+                     @onclick="() => OnEventClick.InvokeAsync(t)"
+                     @onclick:stopPropagation="true">
+                    <div class="dcal__event-title">@t.Name</div>
+                    <div class="dcal__event-range aurora-mono">@FormatRange(t)</div>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/Timinute/Client/Components/Scheduler/DayCalendar.razor
+++ b/Timinute/Client/Components/Scheduler/DayCalendar.razor
@@ -28,13 +28,22 @@
 
     protected override void OnParametersSet()
     {
-        // If the host hands us a new week, default the selection to today when in range,
-        // otherwise the first day of that week.
-        if (SelectedDay == default || SelectedDay < WeekStart || SelectedDay >= WeekStart.AddDays(7))
+        // First mount: prefer today when it falls in the visible week, otherwise the
+        // start of the week.
+        if (SelectedDay == default)
         {
             SelectedDay = (DateTime.Today >= WeekStart && DateTime.Today < WeekStart.AddDays(7))
                 ? DateTime.Today
                 : WeekStart;
+            return;
+        }
+
+        // Week navigation: preserve the user's weekday selection across prev/next so
+        // the visible column stays put. Selected Friday → still Friday in the new week.
+        if (SelectedDay < WeekStart || SelectedDay >= WeekStart.AddDays(7))
+        {
+            var daysFromMonday = ((int)SelectedDay.DayOfWeek + 6) % 7; // Mon=0..Sun=6
+            SelectedDay = WeekStart.AddDays(daysFromMonday);
         }
     }
 

--- a/Timinute/Client/Components/Scheduler/DayCalendar.razor.css
+++ b/Timinute/Client/Components/Scheduler/DayCalendar.razor.css
@@ -1,0 +1,204 @@
+.dcal {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    font-family: var(--font-sans);
+    color: var(--text);
+}
+
+/* Week strip */
+.dcal__strip {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    padding: 8px;
+    box-shadow: var(--shadow-card);
+}
+
+.dcal__strip-day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 8px 4px;
+    border: none;
+    border-radius: 12px;
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    transition: background .15s ease, color .15s ease, box-shadow .15s ease;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.dcal__strip-day:hover {
+    background: var(--surface-2);
+}
+
+.dcal__strip-day.is-selected {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 6px 18px -6px color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.dcal__strip-day.is-selected .dcal__strip-eyebrow,
+.dcal__strip-day.is-selected .dcal__strip-num {
+    color: #fff;
+}
+
+.dcal__strip-eyebrow {
+    font: 500 10px var(--font-sans);
+    color: var(--text-mu);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.dcal__strip-num {
+    font: 600 17px var(--font-sans);
+    color: var(--text);
+    line-height: 1;
+}
+
+/* Day header */
+.dcal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0 4px;
+}
+
+.dcal__header-label {
+    font: 500 14px var(--font-sans);
+    color: var(--text);
+}
+
+.dcal__header-sub {
+    font: 400 12px var(--font-sans);
+    color: var(--text-mu);
+    margin-top: 2px;
+}
+
+.dcal__segmented {
+    display: inline-flex;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 3px;
+}
+
+.dcal__segmented-btn {
+    background: transparent;
+    border: none;
+    padding: 5px 10px;
+    font: 500 12px var(--font-sans);
+    color: var(--text-mu);
+    border-radius: 7px;
+    cursor: pointer;
+}
+
+.dcal__segmented-btn:hover:not(:disabled):not(.is-active) {
+    color: var(--text);
+}
+
+.dcal__segmented-btn:disabled {
+    cursor: not-allowed;
+    opacity: .5;
+}
+
+.dcal__segmented-btn.is-active {
+    background: var(--accent);
+    color: #fff;
+}
+
+/* Day grid */
+.dcal__grid {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+}
+
+.dcal__hours {
+    border-right: 1px solid var(--border);
+}
+
+.dcal__hour {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    padding: 4px 8px 0 0;
+    font: 400 10px var(--font-mono);
+    color: var(--text-mu);
+    box-sizing: border-box;
+}
+
+.dcal__events {
+    position: relative;
+}
+
+.dcal__cell {
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.dcal__cell:hover {
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+}
+
+.dcal__now-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--danger);
+    pointer-events: none;
+    z-index: 2;
+}
+
+.dcal__now-dot {
+    position: absolute;
+    left: -5px;
+    top: -4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--danger);
+}
+
+.dcal__event {
+    position: absolute;
+    left: 6px;
+    right: 6px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    z-index: 3;
+    overflow: hidden;
+    transition: filter .15s ease;
+}
+
+.dcal__event:hover {
+    filter: brightness(.97);
+}
+
+.dcal__event-title {
+    font: 500 11.5px var(--font-sans);
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dcal__event-range {
+    font-size: 10px;
+    color: var(--text-mu);
+    margin-top: 2px;
+}

--- a/Timinute/Client/Pages/Profile.razor.css
+++ b/Timinute/Client/Pages/Profile.razor.css
@@ -86,9 +86,31 @@
     }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
+    .aurora-profile-page {
+        padding: 12px 16px 16px;
+    }
+
     .aurora-profile__header {
         flex-direction: column;
         align-items: flex-start;
+        gap: 14px;
+    }
+
+    .aurora-profile__actions {
+        width: 100%;
+    }
+
+    .aurora-profile__actions > * {
+        flex: 1;
+    }
+
+    .aurora-profile__stats {
+        margin-top: 20px;
+    }
+
+    .aurora-profile-stat__value {
+        font-size: 20px;
+        letter-spacing: -0.5px;
     }
 }

--- a/Timinute/Client/Pages/Projects/ProjectManager.razor.css
+++ b/Timinute/Client/Pages/Projects/ProjectManager.razor.css
@@ -154,8 +154,22 @@
     }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
+    .aurora-pm-page {
+        padding: 12px 16px 16px;
+        gap: 14px;
+    }
+
     .aurora-pm-grid {
         grid-template-columns: 1fr;
+        gap: 12px;
+    }
+
+    .aurora-pm-card {
+        padding: 16px !important;
+    }
+
+    .aurora-pm-spark {
+        height: 28px;
     }
 }

--- a/Timinute/Client/Pages/TimeTracker.razor.css
+++ b/Timinute/Client/Pages/TimeTracker.razor.css
@@ -299,3 +299,66 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* Mobile: timer is centered, action row centers around the play/pause
+   button (reset · play/pause · edit), and project/tags/manual-entry stack
+   below the task name. */
+@media (max-width: 768px) {
+    .aurora-tracker-page {
+        padding: 12px 16px 16px;
+        gap: 14px;
+    }
+
+    .aurora-tracker-card {
+        padding: 24px 18px;
+    }
+
+    .aurora-tracker-card__top {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 16px;
+    }
+
+    .aurora-tracker-card__left {
+        width: 100%;
+    }
+
+    .aurora-tracker-card__label {
+        justify-content: center;
+    }
+
+    .aurora-timer {
+        font-size: 60px;
+        letter-spacing: -2.5px;
+    }
+
+    .aurora-tracker-card__meta {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .aurora-tracker-card__right {
+        gap: 18px;
+        justify-content: center;
+    }
+
+    .aurora-tracker-card__inputs {
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+    }
+
+    .aurora-tracker-tile--name {
+        grid-column: 1 / -1;
+    }
+
+    .aurora-today__row {
+        grid-template-columns: 4px 1fr auto;
+        row-gap: 4px;
+    }
+
+    .aurora-today__range,
+    .aurora-today__actions {
+        display: none;
+    }
+}

--- a/Timinute/Client/Pages/TrackedTasks/TrackedTaskScheduler.razor
+++ b/Timinute/Client/Pages/TrackedTasks/TrackedTaskScheduler.razor
@@ -28,33 +28,46 @@
 
         <div style="flex: 1;"></div>
 
-        <div class="aurora-sched-segmented">
-            <button class="aurora-sched-segmented__btn" disabled title="Coming soon">Day</button>
-            <button class="aurora-sched-segmented__btn is-active">Week</button>
-            <button class="aurora-sched-segmented__btn" disabled title="Coming soon">Month</button>
-        </div>
+        @if (!IsMobile)
+        {
+            <div class="aurora-sched-segmented">
+                <button class="aurora-sched-segmented__btn" disabled title="Coming soon">Day</button>
+                <button class="aurora-sched-segmented__btn is-active">Week</button>
+                <button class="aurora-sched-segmented__btn" disabled title="Coming soon">Month</button>
+            </div>
 
-        <AuroraButton Variant="primary" OnClick="OpenAdd">
-            <AuroraIcons Name="plus" Size="16" />
-            <span>Add task</span>
-        </AuroraButton>
+            <AuroraButton Variant="primary" OnClick="OpenAdd">
+                <AuroraIcons Name="plus" Size="16" />
+                <span>Add task</span>
+            </AuroraButton>
+        }
     </div>
 
-    <AuroraCard NoPad="true">
-        @if (IsLoading)
-        {
+    @if (IsLoading)
+    {
+        <AuroraCard NoPad="true">
             <div class="aurora-sched-loading">Loading…</div>
-        }
-        else
-        {
+        </AuroraCard>
+    }
+    else if (IsMobile)
+    {
+        <DayCalendar WeekStart="@WeekStart" Tasks="@WeekTasks"
+                     OnEmptyClick="@OnEmptyCellClicked"
+                     OnEventClick="@OnEventClicked" />
+    }
+    else
+    {
+        <AuroraCard NoPad="true">
             <WeekCalendar WeekStart="@WeekStart" Tasks="@WeekTasks"
                           OnEmptyClick="@OnEmptyCellClicked"
                           OnEventClick="@OnEventClicked" />
-        }
-    </AuroraCard>
+        </AuroraCard>
+    }
 </div>
 
 @code {
+    [CascadingParameter(Name = "IsMobile")] public bool IsMobile { get; set; }
+
     private DateTime WeekStart;
     private bool IsLoading = true;
     private List<TrackedTaskDto> WeekTasks = new();

--- a/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
+++ b/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
@@ -166,3 +166,53 @@
         text-align: left;
     }
 }
+
+/* Mobile: filter bar collapses to search + primary +. Day-group rows
+   stack name on top, project pill + time-range as a meta line, mono
+   duration right-aligned. */
+@media (max-width: 768px) {
+    .aurora-tt-page {
+        padding: 12px 16px 16px;
+        gap: 12px;
+    }
+
+    .aurora-tt-filter > .aurora-btn--ghost {
+        display: none;
+    }
+
+    .aurora-tt-row {
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "name duration"
+            "meta meta";
+        row-gap: 4px;
+        column-gap: 10px;
+        padding: 12px 14px;
+    }
+
+    .aurora-tt-row__name {
+        grid-area: name;
+    }
+
+    .aurora-tt-row__duration {
+        grid-area: duration;
+        text-align: right;
+        font-size: 13px;
+    }
+
+    .aurora-tt-row__pill {
+        grid-area: meta;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .aurora-tt-row__pill::after {
+        content: attr(data-range);
+    }
+
+    .aurora-tt-row__range,
+    .aurora-tt-row__actions {
+        display: none;
+    }
+}

--- a/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
+++ b/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
@@ -184,10 +184,11 @@
         grid-template-columns: 1fr auto;
         grid-template-areas:
             "name duration"
-            "meta meta";
+            "pill range";
         row-gap: 4px;
         column-gap: 10px;
         padding: 12px 14px;
+        align-items: center;
     }
 
     .aurora-tt-row__name {
@@ -201,17 +202,17 @@
     }
 
     .aurora-tt-row__pill {
-        grid-area: meta;
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
+        grid-area: pill;
+        justify-self: start;
     }
 
-    .aurora-tt-row__pill::after {
-        content: attr(data-range);
+    .aurora-tt-row__range {
+        grid-area: range;
+        text-align: right;
+        font-size: 12px;
+        color: var(--text-mu);
     }
 
-    .aurora-tt-row__range,
     .aurora-tt-row__actions {
         display: none;
     }

--- a/Timinute/Client/Pages/Trash.razor.css
+++ b/Timinute/Client/Pages/Trash.razor.css
@@ -92,3 +92,33 @@
         grid-template-columns: 1fr 1fr;
     }
 }
+
+/* Mobile: stack rows. Name on top, date + days-remaining as a meta line,
+   restore/purge buttons stacked full-width below. */
+@media (max-width: 768px) {
+    .aurora-trash-page {
+        padding: 12px 16px 16px;
+        gap: 16px;
+    }
+
+    .aurora-trash-row {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        padding: 14px 14px;
+    }
+
+    .aurora-trash-row__date,
+    .aurora-trash-row__remaining {
+        font-size: 12.5px;
+    }
+
+    .aurora-trash-row__actions {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .aurora-trash-row__actions > .aurora-btn {
+        flex: 1;
+    }
+}

--- a/Timinute/Client/Program.cs
+++ b/Timinute/Client/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddScoped<DialogService>();
 builder.Services.AddScoped<Timinute.Client.Services.UndoNotificationService>();
 builder.Services.AddScoped<Timinute.Client.Services.ProjectColorService>();
 builder.Services.AddScoped<Timinute.Client.Services.ViewportService>();
+builder.Services.AddScoped<Timinute.Client.Services.MobileSheetService>();
 
 builder.Services.AddOidcAuthentication(options =>
 {

--- a/Timinute/Client/Program.cs
+++ b/Timinute/Client/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<DialogService>();
 builder.Services.AddScoped<Timinute.Client.Services.UndoNotificationService>();
 builder.Services.AddScoped<Timinute.Client.Services.ProjectColorService>();
+builder.Services.AddScoped<Timinute.Client.Services.ViewportService>();
 
 builder.Services.AddOidcAuthentication(options =>
 {

--- a/Timinute/Client/Services/MobileSheetService.cs
+++ b/Timinute/Client/Services/MobileSheetService.cs
@@ -1,0 +1,31 @@
+namespace Timinute.Client.Services
+{
+    /// <summary>
+    /// Tiny scoped service that lets the mobile topbar avatar tell the
+    /// MobileMoreSheet to show itself without a direct component reference.
+    /// </summary>
+    public class MobileSheetService
+    {
+        public bool IsOpen { get; private set; }
+        public event Action? OnChange;
+
+        public void Show()
+        {
+            if (IsOpen) return;
+            IsOpen = true;
+            OnChange?.Invoke();
+        }
+
+        public void Hide()
+        {
+            if (!IsOpen) return;
+            IsOpen = false;
+            OnChange?.Invoke();
+        }
+
+        public void Toggle()
+        {
+            if (IsOpen) Hide(); else Show();
+        }
+    }
+}

--- a/Timinute/Client/Services/ViewportService.cs
+++ b/Timinute/Client/Services/ViewportService.cs
@@ -23,24 +23,39 @@ namespace Timinute.Client.Services
         }
 
         /// <summary>
-        /// Idempotent. Safe to call from any component that wants to ensure the
-        /// service is bootstrapped — typically MainLayout in OnAfterRenderAsync(firstRender).
+        /// Idempotent on success; retries on failure. Safe to call from any
+        /// component that wants to ensure the service is bootstrapped — typically
+        /// MainLayout in OnAfterRenderAsync.
         /// </summary>
         public async ValueTask InitializeAsync()
         {
             if (initialized) return;
-            initialized = true;
 
+            IJSObjectReference? localModule = null;
+            DotNetObjectReference<ViewportService>? localRef = null;
             try
             {
-                module = await js.InvokeAsync<IJSObjectReference>("import", "./js/viewport.js");
-                selfRef = DotNetObjectReference.Create(this);
-                await module.InvokeVoidAsync("register", selfRef);
+                localModule = await js.InvokeAsync<IJSObjectReference>("import", "./js/viewport.js");
+                localRef = DotNetObjectReference.Create(this);
+                await localModule.InvokeVoidAsync("register", localRef);
+
+                // Only commit the registration once everything succeeded — otherwise we'd
+                // leak partially-created handles across retries.
+                module = localModule;
+                selfRef = localRef;
+                initialized = true;
             }
             catch
             {
-                // Prerendering or torn-down circuit — IsMobile stays false; OK as a default.
-                initialized = false;
+                // Prerendering or torn-down circuit. Tear down any partial state so the
+                // next render's retry starts from a clean slate; IsMobile stays false.
+                localRef?.Dispose();
+                if (localModule is not null)
+                {
+                    try { await localModule.DisposeAsync(); }
+                    catch (JSDisconnectedException) { }
+                    catch (JSException) { }
+                }
             }
         }
 
@@ -54,16 +69,25 @@ namespace Timinute.Client.Services
 
         public async ValueTask DisposeAsync()
         {
-            if (module is not null)
+            try
             {
-                try
+                if (module is not null)
                 {
-                    await module.InvokeVoidAsync("unregister");
-                    await module.DisposeAsync();
+                    try
+                    {
+                        await module.InvokeVoidAsync("unregister");
+                        await module.DisposeAsync();
+                    }
+                    catch (JSDisconnectedException) { }
+                    catch (JSException) { }
                 }
-                catch (JSDisconnectedException) { }
             }
-            selfRef?.Dispose();
+            finally
+            {
+                selfRef?.Dispose();
+                selfRef = null;
+                module = null;
+            }
         }
     }
 }

--- a/Timinute/Client/Services/ViewportService.cs
+++ b/Timinute/Client/Services/ViewportService.cs
@@ -1,0 +1,69 @@
+using Microsoft.JSInterop;
+
+namespace Timinute.Client.Services
+{
+    /// <summary>
+    /// Single source of truth for whether the viewport is in the mobile breakpoint
+    /// (≤768px). Backed by a tiny ES module that listens to a matchMedia change
+    /// event and pushes updates here via JS interop.
+    /// </summary>
+    public class ViewportService : IAsyncDisposable
+    {
+        private readonly IJSRuntime js;
+        private IJSObjectReference? module;
+        private DotNetObjectReference<ViewportService>? selfRef;
+        private bool initialized;
+
+        public bool IsMobile { get; private set; }
+        public event Action? OnChanged;
+
+        public ViewportService(IJSRuntime js)
+        {
+            this.js = js;
+        }
+
+        /// <summary>
+        /// Idempotent. Safe to call from any component that wants to ensure the
+        /// service is bootstrapped — typically MainLayout in OnAfterRenderAsync(firstRender).
+        /// </summary>
+        public async ValueTask InitializeAsync()
+        {
+            if (initialized) return;
+            initialized = true;
+
+            try
+            {
+                module = await js.InvokeAsync<IJSObjectReference>("import", "./js/viewport.js");
+                selfRef = DotNetObjectReference.Create(this);
+                await module.InvokeVoidAsync("register", selfRef);
+            }
+            catch
+            {
+                // Prerendering or torn-down circuit — IsMobile stays false; OK as a default.
+                initialized = false;
+            }
+        }
+
+        [JSInvokable]
+        public void SetIsMobile(bool value)
+        {
+            if (IsMobile == value) return;
+            IsMobile = value;
+            OnChanged?.Invoke();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (module is not null)
+            {
+                try
+                {
+                    await module.InvokeVoidAsync("unregister");
+                    await module.DisposeAsync();
+                }
+                catch (JSDisconnectedException) { }
+            }
+            selfRef?.Dispose();
+        }
+    }
+}

--- a/Timinute/Client/Shared/AuroraIcons.razor
+++ b/Timinute/Client/Shared/AuroraIcons.razor
@@ -115,5 +115,10 @@
         case "sparkle":
             <path d="M12 3v6M12 15v6M3 12h6M15 12h6" />
             break;
+        case "logout":
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <path d="M21 12H9" />
+            break;
     }
 </svg>

--- a/Timinute/Client/Shared/MainLayout.razor
+++ b/Timinute/Client/Shared/MainLayout.razor
@@ -11,12 +11,20 @@
     <AuthorizeView>
         <Authorized>
             <div class="aurora-app @(Viewport.IsMobile ? "is-mobile" : "")">
-                <NavMenu />
+                @if (!Viewport.IsMobile)
+                {
+                    <NavMenu />
+                }
                 <main class="aurora-main">
                     <Topbar />
                     <article class="aurora-content">
                         @Body
                     </article>
+                    @if (Viewport.IsMobile)
+                    {
+                        <MobileTabBar />
+                        <MobileMoreSheet />
+                    }
                 </main>
             </div>
         </Authorized>

--- a/Timinute/Client/Shared/MainLayout.razor
+++ b/Timinute/Client/Shared/MainLayout.razor
@@ -45,10 +45,11 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            await Viewport.InitializeAsync();
-        }
+        // No `firstRender` guard: InitializeAsync is internally idempotent on success
+        // and resets its `initialized` flag on failure, so calling it on every render
+        // gives us a free retry path if the first JS import is racing prerender or
+        // hot reload. The dedupe is cheap (a single bool check after the first hit).
+        await Viewport.InitializeAsync();
     }
 
     private void OnViewportChanged()

--- a/Timinute/Client/Shared/MainLayout.razor
+++ b/Timinute/Client/Shared/MainLayout.razor
@@ -1,26 +1,55 @@
 @inherits LayoutComponentBase
+@implements IDisposable
+@inject Timinute.Client.Services.ViewportService Viewport
 
 <head>
     <RadzenTheme Theme="material" @rendermode="RenderMode.InteractiveAuto" />
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)"></script>
 </head>
 
-<AuthorizeView>
-    <Authorized>
-        <div class="aurora-app">
-            <NavMenu />
-            <main class="aurora-main">
-                <Topbar />
-                <article class="aurora-content">
-                    @Body
-                </article>
-            </main>
-        </div>
-    </Authorized>
-    <NotAuthorized>
-        @Body
-    </NotAuthorized>
-</AuthorizeView>
+<CascadingValue Value="Viewport.IsMobile" Name="IsMobile">
+    <AuthorizeView>
+        <Authorized>
+            <div class="aurora-app @(Viewport.IsMobile ? "is-mobile" : "")">
+                <NavMenu />
+                <main class="aurora-main">
+                    <Topbar />
+                    <article class="aurora-content">
+                        @Body
+                    </article>
+                </main>
+            </div>
+        </Authorized>
+        <NotAuthorized>
+            @Body
+        </NotAuthorized>
+    </AuthorizeView>
+</CascadingValue>
 
 <RadzenDialog />
 <RadzenNotification />
+
+@code {
+    protected override void OnInitialized()
+    {
+        Viewport.OnChanged += OnViewportChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Viewport.InitializeAsync();
+        }
+    }
+
+    private void OnViewportChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        Viewport.OnChanged -= OnViewportChanged;
+    }
+}

--- a/Timinute/Client/Shared/MainLayout.razor.css
+++ b/Timinute/Client/Shared/MainLayout.razor.css
@@ -11,8 +11,20 @@
     flex-direction: column;
     overflow: auto;
     min-width: 0;
+    position: relative;
 }
 
 .aurora-content {
     flex: 1;
+}
+
+/* Mobile shell — sidebar is removed entirely (gated in markup), tab bar
+   sits absolutely at the bottom of .aurora-main, content gets a tail
+   padding so the last list row doesn't hide under the bar. */
+.aurora-app.is-mobile {
+    height: 100dvh;
+}
+
+.aurora-app.is-mobile .aurora-content {
+    padding-bottom: calc(100px + env(safe-area-inset-bottom, 0px));
 }

--- a/Timinute/Client/Shared/MobileMoreSheet.razor
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor
@@ -1,1 +1,74 @@
-@* Stub — full implementation lands in step 5. Keeps MainLayout's reference compilable. *@
+@implements IDisposable
+@inject Timinute.Client.Services.MobileSheetService Sheet
+@inject NavigationManager Navigation
+@inject Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager SignOutManager
+
+@if (Sheet.IsOpen)
+{
+    <div class="mms__backdrop" @onclick="Close"></div>
+    <aside class="mms" role="dialog" aria-label="More navigation">
+        <div class="mms__handle" aria-hidden="true"></div>
+
+        @foreach (var item in Items)
+        {
+            <button type="button" class="mms__row" @onclick="@(() => Go(item.Href))">
+                <span class="mms__icon">
+                    <AuroraIcons Name="@item.Icon" Size="20" />
+                </span>
+                <span class="mms__label">@item.Label</span>
+                <span class="mms__chevron" aria-hidden="true">
+                    <AuroraIcons Name="arrowR" Size="16" />
+                </span>
+            </button>
+        }
+
+        <button type="button" class="mms__row mms__row--danger" @onclick="LogOut">
+            <span class="mms__icon">
+                <AuroraIcons Name="arrowR" Size="20" />
+            </span>
+            <span class="mms__label">Log out</span>
+            <span class="mms__chevron" aria-hidden="true"></span>
+        </button>
+    </aside>
+}
+
+@code {
+    private record SheetItem(string Label, string Href, string Icon);
+
+    private static readonly SheetItem[] Items =
+    {
+        new("Profile",  "profile",   "user"),
+        new("Calendar", "scheduler", "calendar"),
+        new("Trash",    "trash",     "trash"),
+    };
+
+    protected override void OnInitialized()
+    {
+        Sheet.OnChange += OnChange;
+    }
+
+    private void OnChange()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void Close() => Sheet.Hide();
+
+    private void Go(string href)
+    {
+        Sheet.Hide();
+        Navigation.NavigateTo(href);
+    }
+
+    private async Task LogOut()
+    {
+        Sheet.Hide();
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+
+    public void Dispose()
+    {
+        Sheet.OnChange -= OnChange;
+    }
+}

--- a/Timinute/Client/Shared/MobileMoreSheet.razor
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor
@@ -6,7 +6,12 @@
 @if (Sheet.IsOpen)
 {
     <div class="mms__backdrop" @onclick="Close"></div>
-    <aside class="mms" role="dialog" aria-label="More navigation">
+    <aside class="mms"
+           role="dialog"
+           aria-modal="true"
+           aria-label="More navigation"
+           tabindex="-1"
+           @onkeydown="HandleKeyDown">
         <div class="mms__handle" aria-hidden="true"></div>
 
         @foreach (var item in Items)
@@ -24,7 +29,7 @@
 
         <button type="button" class="mms__row mms__row--danger" @onclick="LogOut">
             <span class="mms__icon">
-                <AuroraIcons Name="arrowR" Size="20" />
+                <AuroraIcons Name="logout" Size="20" />
             </span>
             <span class="mms__label">Log out</span>
             <span class="mms__chevron" aria-hidden="true"></span>
@@ -53,6 +58,14 @@
     }
 
     private void Close() => Sheet.Hide();
+
+    private void HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            Sheet.Hide();
+        }
+    }
 
     private void Go(string href)
     {

--- a/Timinute/Client/Shared/MobileMoreSheet.razor
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor
@@ -11,6 +11,7 @@
            aria-modal="true"
            aria-label="More navigation"
            tabindex="-1"
+           @ref="sheetEl"
            @onkeydown="HandleKeyDown">
         <div class="mms__handle" aria-hidden="true"></div>
 
@@ -47,6 +48,9 @@
         new("Trash",    "trash",     "trash"),
     };
 
+    private ElementReference sheetEl;
+    private bool needsFocus;
+
     protected override void OnInitialized()
     {
         Sheet.OnChange += OnChange;
@@ -54,7 +58,20 @@
 
     private void OnChange()
     {
+        // When the sheet opens, queue a focus pass so Escape and screen-reader
+        // announcement land on the dialog instead of the trigger button.
+        if (Sheet.IsOpen) needsFocus = true;
         InvokeAsync(StateHasChanged);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (needsFocus && Sheet.IsOpen)
+        {
+            needsFocus = false;
+            try { await sheetEl.FocusAsync(preventScroll: true); }
+            catch (Microsoft.JSInterop.JSException) { /* element may have unmounted */ }
+        }
     }
 
     private void Close() => Sheet.Hide();

--- a/Timinute/Client/Shared/MobileMoreSheet.razor
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor
@@ -1,0 +1,1 @@
+@* Stub — full implementation lands in step 5. Keeps MainLayout's reference compilable. *@

--- a/Timinute/Client/Shared/MobileMoreSheet.razor.css
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor.css
@@ -1,0 +1,97 @@
+.mms__backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(20, 18, 40, .42);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    z-index: 60;
+    animation: mms-backdrop-in .18s ease-out;
+}
+
+@keyframes mms-backdrop-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.mms {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: calc(96px + env(safe-area-inset-bottom, 0px));
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 22px;
+    padding: 12px 8px;
+    z-index: 61;
+    box-shadow: 0 30px 60px -20px rgba(20, 18, 40, .25);
+    animation: mms-in .22s cubic-bezier(.2, .8, .2, 1);
+    transform-origin: bottom center;
+}
+
+@keyframes mms-in {
+    from { transform: translateY(20px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+}
+
+.mms__handle {
+    width: 36px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border);
+    margin: 0 auto 8px;
+}
+
+.mms__row {
+    display: grid;
+    grid-template-columns: 28px 1fr 16px;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 14px 14px;
+    background: transparent;
+    border: none;
+    border-radius: 12px;
+    color: var(--text);
+    font: 500 15px var(--font-sans);
+    text-align: left;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background .15s ease;
+}
+
+.mms__row:hover,
+.mms__row:focus-visible {
+    background: var(--surface-2);
+    outline: none;
+}
+
+.mms__row + .mms__row {
+    margin-top: 2px;
+}
+
+.mms__icon {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: var(--accent-so);
+    color: var(--accent-ink);
+}
+
+.mms__chevron {
+    color: var(--text-dim);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mms__row--danger {
+    color: var(--danger);
+}
+
+.mms__row--danger .mms__icon {
+    background: color-mix(in srgb, var(--danger) 12%, transparent);
+    color: var(--danger);
+}

--- a/Timinute/Client/Shared/MobileMoreSheet.razor.css
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor.css
@@ -59,10 +59,14 @@
     transition: background .15s ease;
 }
 
-.mms__row:hover,
+.mms__row:hover {
+    background: var(--surface-2);
+}
+
 .mms__row:focus-visible {
     background: var(--surface-2);
-    outline: none;
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
 }
 
 .mms__row + .mms__row {

--- a/Timinute/Client/Shared/MobileTabBar.razor
+++ b/Timinute/Client/Shared/MobileTabBar.razor
@@ -1,1 +1,82 @@
-@* Stub — full implementation lands in step 4. Keeps MainLayout's reference compilable. *@
+@implements IDisposable
+@inject NavigationManager Navigation
+@inject Radzen.DialogService DialogService
+
+<nav class="mtb" aria-label="Primary mobile navigation">
+    @foreach (var item in LeftItems)
+    {
+        <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
+           href="@item.Href" aria-label="@item.Label">
+            <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
+            <span class="mtb__label">@item.Label</span>
+        </a>
+    }
+
+    <button class="mtb__fab" type="button" @onclick="OpenQuickAdd" aria-label="Quick add">
+        <AuroraIcons Name="plus" Size="22" StrokeWidth="2.2" />
+    </button>
+
+    @foreach (var item in RightItems)
+    {
+        <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
+           href="@item.Href" aria-label="@item.Label">
+            <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
+            <span class="mtb__label">@item.Label</span>
+        </a>
+    }
+</nav>
+
+@code {
+    private record TabItem(string Label, string Href, string Icon);
+
+    // Order matters — these flank the FAB. Left two on the left, right two on the right.
+    private static readonly TabItem[] LeftItems =
+    {
+        new("Home",    "",              "dashboard"),
+        new("Tracker", "timetracker",   "timer"),
+    };
+
+    private static readonly TabItem[] RightItems =
+    {
+        new("Tasks",    "trackedtasks",   "list"),
+        new("Projects", "projectmanager", "folder"),
+    };
+
+    protected override void OnInitialized()
+    {
+        Navigation.LocationChanged += OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        Navigation.LocationChanged -= OnLocationChanged;
+    }
+
+    private bool IsActive(string href)
+    {
+        var current = Navigation.ToBaseRelativePath(Navigation.Uri);
+        var queryIdx = current.IndexOf('?');
+        if (queryIdx >= 0) current = current.Substring(0, queryIdx);
+        var fragIdx = current.IndexOf('#');
+        if (fragIdx >= 0) current = current.Substring(0, fragIdx);
+        current = current.TrimEnd('/');
+        var target = href.TrimEnd('/');
+
+        if (string.IsNullOrEmpty(target)) return current.Length == 0;
+        return current.Equals(target, StringComparison.OrdinalIgnoreCase)
+            || current.StartsWith(target + "/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task OpenQuickAdd()
+    {
+        await DialogService.OpenAsync<Timinute.Client.Components.TrackedTasks.AddTrackedTask>(
+            "Quick add",
+            new Dictionary<string, object?>(),
+            new Radzen.DialogOptions { Width = "min(560px, 92vw)" });
+    }
+}

--- a/Timinute/Client/Shared/MobileTabBar.razor
+++ b/Timinute/Client/Shared/MobileTabBar.razor
@@ -1,0 +1,1 @@
+@* Stub — full implementation lands in step 4. Keeps MainLayout's reference compilable. *@

--- a/Timinute/Client/Shared/MobileTabBar.razor
+++ b/Timinute/Client/Shared/MobileTabBar.razor
@@ -6,7 +6,8 @@
     @foreach (var item in LeftItems)
     {
         <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
-           href="@item.Href" aria-label="@item.Label">
+           href="@item.Href" aria-label="@item.Label"
+           aria-current="@(IsActive(item.Href) ? "page" : null)">
             <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
             <span class="mtb__label">@item.Label</span>
         </a>
@@ -19,7 +20,8 @@
     @foreach (var item in RightItems)
     {
         <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
-           href="@item.Href" aria-label="@item.Label">
+           href="@item.Href" aria-label="@item.Label"
+           aria-current="@(IsActive(item.Href) ? "page" : null)">
             <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
             <span class="mtb__label">@item.Label</span>
         </a>

--- a/Timinute/Client/Shared/MobileTabBar.razor
+++ b/Timinute/Client/Shared/MobileTabBar.razor
@@ -5,9 +5,10 @@
 <nav class="mtb" aria-label="Primary mobile navigation">
     @foreach (var item in LeftItems)
     {
-        <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
+        var isActive = IsActive(item.Href);
+        <a class="mtb__item @(isActive ? "is-active" : "")"
            href="@item.Href" aria-label="@item.Label"
-           aria-current="@(IsActive(item.Href) ? "page" : null)">
+           aria-current="@(isActive ? "page" : null)">
             <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
             <span class="mtb__label">@item.Label</span>
         </a>
@@ -19,9 +20,10 @@
 
     @foreach (var item in RightItems)
     {
-        <a class="mtb__item @(IsActive(item.Href) ? "is-active" : "")"
+        var isActive = IsActive(item.Href);
+        <a class="mtb__item @(isActive ? "is-active" : "")"
            href="@item.Href" aria-label="@item.Label"
-           aria-current="@(IsActive(item.Href) ? "page" : null)">
+           aria-current="@(isActive ? "page" : null)">
             <AuroraIcons Name="@item.Icon" Size="21" StrokeWidth="1.8" />
             <span class="mtb__label">@item.Label</span>
         </a>

--- a/Timinute/Client/Shared/MobileTabBar.razor.css
+++ b/Timinute/Client/Shared/MobileTabBar.razor.css
@@ -1,0 +1,79 @@
+.mtb {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    height: 60px;
+    display: grid;
+    grid-template-columns: 1fr 1fr 60px 1fr 1fr;
+    align-items: center;
+    padding: 0 12px;
+    background: color-mix(in srgb, var(--surface) 85%, transparent);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid var(--border);
+    border-radius: 22px;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, .4),
+        0 12px 30px -12px rgba(20, 18, 40, .18);
+    z-index: 50;
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+    .mtb {
+        background: color-mix(in srgb, var(--surface) 95%, transparent);
+    }
+}
+
+.mtb__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    height: 100%;
+    text-decoration: none;
+    color: var(--text-mu);
+    font: 500 10px var(--font-sans);
+    letter-spacing: -0.1px;
+    transition: color .15s ease;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.mtb__item:hover {
+    color: var(--text);
+}
+
+.mtb__item.is-active {
+    color: var(--accent);
+}
+
+.mtb__label {
+    line-height: 1;
+}
+
+.mtb__fab {
+    width: 44px;
+    height: 44px;
+    margin: 0 auto;
+    margin-top: -14px;
+    border: none;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--accent), #8B6FFF);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 8px 18px -4px color-mix(in srgb, var(--accent) 55%, transparent);
+    transition: transform .08s ease, filter .15s ease;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.mtb__fab:hover {
+    filter: brightness(1.05);
+}
+
+.mtb__fab:active {
+    transform: scale(.95);
+}

--- a/Timinute/Client/Shared/Topbar.razor
+++ b/Timinute/Client/Shared/Topbar.razor
@@ -84,7 +84,9 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        // Skip the Cmd/Ctrl+K module on mobile — the search input isn't rendered
+        // and there's no on-screen keyboard affordance for the shortcut.
+        if (firstRender && !IsMobile && shortcutsModule is null)
         {
             shortcutsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/topbar-shortcuts.js");
             await shortcutsModule.InvokeVoidAsync("registerCmdKFocus", ".aurora-search__input");

--- a/Timinute/Client/Shared/Topbar.razor
+++ b/Timinute/Client/Shared/Topbar.razor
@@ -3,6 +3,7 @@
 @inject AuthenticationStateProvider AuthState
 @inject Radzen.DialogService DialogService
 @inject IJSRuntime JS
+@inject Timinute.Client.Services.MobileSheetService Sheet
 
 <header class="aurora-topbar">
     <div class="aurora-topbar__left">
@@ -11,18 +12,27 @@
     </div>
 
     <div class="aurora-topbar__right">
-        <div class="aurora-search">
-            <span class="aurora-search__icon">
-                <AuroraIcons Name="search" Size="16" />
-            </span>
-            <input type="text" class="aurora-search__input" placeholder="Search tasks, projects…" />
-            <span class="aurora-search__chip">⌘K</span>
-        </div>
+        @if (!IsMobile)
+        {
+            <div class="aurora-search">
+                <span class="aurora-search__icon">
+                    <AuroraIcons Name="search" Size="16" />
+                </span>
+                <input type="text" class="aurora-search__input" placeholder="Search tasks, projects…" />
+                <span class="aurora-search__chip">⌘K</span>
+            </div>
 
-        <button class="aurora-quick-add" @onclick="OpenQuickAdd">
-            <AuroraIcons Name="plus" Size="16" />
-            <span>Quick add</span>
-        </button>
+            <button class="aurora-quick-add" @onclick="OpenQuickAdd">
+                <AuroraIcons Name="plus" Size="16" />
+                <span>Quick add</span>
+            </button>
+        }
+        else
+        {
+            <button type="button" class="aurora-topbar__avatar" @onclick="OpenSheet" aria-label="More">
+                @Initials
+            </button>
+        }
     </div>
 </header>
 
@@ -38,10 +48,24 @@
         ["trash"]                  = ("Trash",         "Restore or permanently delete."),
     };
 
+    [CascadingParameter(Name = "IsMobile")] public bool IsMobile { get; set; }
+
     private string CurrentTitle = "Timinute";
     private string CurrentSubtitle = "";
     private string FirstName = "";
+    private string LastName = "";
     private IJSObjectReference? shortcutsModule;
+
+    private string Initials
+    {
+        get
+        {
+            var f = string.IsNullOrWhiteSpace(FirstName) ? "" : FirstName.Trim()[0].ToString();
+            var l = string.IsNullOrWhiteSpace(LastName) ? "" : LastName.Trim()[0].ToString();
+            var combined = (f + l).ToUpperInvariant();
+            return combined.Length == 0 ? "?" : combined;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -53,6 +77,7 @@
             FirstName = user.FindFirst(System.Security.Claims.ClaimTypes.GivenName)?.Value
                        ?? user.Identity.Name?.Split('@')[0]
                        ?? "";
+            LastName = user.FindFirst(System.Security.Claims.ClaimTypes.Surname)?.Value ?? "";
         }
         Resolve();
     }
@@ -111,6 +136,8 @@
             new Dictionary<string, object?>(),
             new Radzen.DialogOptions { Width = "640px" });
     }
+
+    private void OpenSheet() => Sheet.Show();
 
     public async ValueTask DisposeAsync()
     {

--- a/Timinute/Client/Shared/Topbar.razor.css
+++ b/Timinute/Client/Shared/Topbar.razor.css
@@ -103,3 +103,49 @@
 .aurora-quick-add:active {
     transform: scale(.97);
 }
+
+/* Mobile-only avatar trigger that opens MobileMoreSheet. Rendered only
+   when IsMobile is true (markup gates this with @if). */
+.aurora-topbar__avatar {
+    width: 38px;
+    height: 38px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--accent), #9D7CFF);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    font: 600 13px var(--font-sans);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 14px color-mix(in srgb, var(--accent) 35%, transparent);
+    -webkit-tap-highlight-color: transparent;
+    transition: filter .15s ease, transform .08s ease;
+}
+
+.aurora-topbar__avatar:hover {
+    filter: brightness(1.05);
+}
+
+.aurora-topbar__avatar:active {
+    transform: scale(.95);
+}
+
+@media (max-width: 768px) {
+    .aurora-topbar {
+        padding: 6px 20px 14px;
+        gap: 12px;
+    }
+
+    .aurora-topbar__title {
+        font-size: 22px;
+        letter-spacing: -0.6px;
+    }
+
+    .aurora-topbar__subtitle {
+        font-size: 12.5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/Timinute/Client/wwwroot/css/landing.css
+++ b/Timinute/Client/wwwroot/css/landing.css
@@ -813,10 +813,12 @@
         padding-right: 20px;
     }
 
-    /* Top nav: only wordmark + Log in pill survives. */
+    /* Top nav: only wordmark + Log in pill survives. The GitHub link is
+       targeted by its href so the rule doesn't depend on :has() or DOM
+       structure. */
     .lnav__link--features,
     .lnav__link--open,
-    .lnav__link:has(> svg),
+    .lnav__link[href*="github.com"],
     .lnav__cta {
         display: none;
     }

--- a/Timinute/Client/wwwroot/css/landing.css
+++ b/Timinute/Client/wwwroot/css/landing.css
@@ -800,7 +800,9 @@
     }
 }
 
-@media (max-width: 640px) {
+/* Mobile (matches aurora-mobile-landing.jsx). Stacks fully, drops nav
+   anchors, shrinks hero typography, full-width CTAs. */
+@media (max-width: 768px) {
     .aurora-landing__container,
     .lnav,
     .lhero,
@@ -811,21 +813,142 @@
         padding-right: 20px;
     }
 
-    .lnav__links {
-        gap: 14px;
-    }
-
+    /* Top nav: only wordmark + Log in pill survives. */
     .lnav__link--features,
-    .lnav__link--open {
+    .lnav__link--open,
+    .lnav__link:has(> svg),
+    .lnav__cta {
         display: none;
     }
 
+    .lnav__link--login {
+        background: var(--accent-so);
+        color: var(--accent-ink);
+        padding: 8px 14px;
+        border-radius: 999px;
+    }
+
+    /* Hero: smaller H1, smaller intro, stacked full-width CTAs. */
+    .lhero {
+        padding-top: 24px;
+        gap: 28px;
+    }
+
     .lhero__h1 {
-        font-size: 40px;
+        font-size: 42px;
+        letter-spacing: -1.6px;
+        line-height: 1.05;
+    }
+
+    .lhero__intro {
+        font-size: 15px;
+    }
+
+    .lhero__ctas {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .lhero__cta-primary,
+    .lhero__cta-ghost {
+        justify-content: center;
+        width: 100%;
+    }
+
+    .lhero__trust {
+        gap: 12px 14px;
+        font-size: 12.5px;
+    }
+
+    /* Hero card mock */
+    .lhero__card {
+        padding: 22px;
+        border-radius: 22px;
+    }
+
+    .lhero__card-timer {
+        font-size: 46px;
+        letter-spacing: -2px;
+    }
+
+    /* Features: header stacks, card padding tightens. */
+    .lfeatures {
+        padding-top: 80px;
+    }
+
+    .lfeatures__head {
+        flex-direction: column;
+        gap: 14px;
+    }
+
+    .lfeatures__h2 {
+        font-size: 30px;
+        letter-spacing: -1.2px;
+    }
+
+    .lfeature-card {
+        padding: 20px;
+    }
+
+    /* Open-source CTA: compact, two side-by-side full-width buttons,
+       headline wraps. */
+    .loss {
+        margin-top: 80px;
+    }
+
+    .loss__card {
+        padding: 24px;
+        border-radius: 22px;
+    }
+
+    .loss__h2 {
+        font-size: 26px;
+        letter-spacing: -0.8px;
+    }
+
+    .loss__copy {
+        font-size: 14.5px;
+    }
+
+    .loss__buttons {
+        gap: 10px;
+    }
+
+    .loss__btn-primary,
+    .loss__btn-ghost {
+        flex: 1;
+        justify-content: center;
+    }
+
+    .loss__terminal-pre {
+        font-size: 11.5px;
+        padding: 14px;
+    }
+
+    /* Footer: centered single column. */
+    .lfooter {
+        margin-top: 60px;
+        padding-top: 28px;
+        flex-direction: column;
+        align-items: center;
+        gap: 14px;
+        text-align: center;
+    }
+
+    .lfooter__links {
+        justify-content: center;
+    }
+}
+
+/* Tighter hero size at very narrow widths. */
+@media (max-width: 480px) {
+    .lhero__h1 {
+        font-size: 36px;
         letter-spacing: -1.2px;
     }
 
     .lhero__card-timer {
-        font-size: 44px;
+        font-size: 40px;
     }
 }

--- a/Timinute/Client/wwwroot/js/viewport.js
+++ b/Timinute/Client/wwwroot/js/viewport.js
@@ -1,0 +1,33 @@
+// Viewport breakpoint bridge — pushes matchMedia state to .NET.
+// Called once from ViewportService on first render.
+
+let mediaQuery = null;
+let dotnetRef = null;
+
+function notify() {
+    if (dotnetRef) {
+        try {
+            dotnetRef.invokeMethodAsync('SetIsMobile', mediaQuery.matches);
+        } catch {
+            // Connection torn down (page unload, hot reload). Safe to ignore.
+        }
+    }
+}
+
+export function register(reference) {
+    dotnetRef = reference;
+    if (!mediaQuery) {
+        mediaQuery = window.matchMedia('(max-width: 768px)');
+        mediaQuery.addEventListener('change', notify);
+    }
+    // Push initial value immediately so the cascade is correct on first render.
+    notify();
+}
+
+export function unregister() {
+    if (mediaQuery) {
+        mediaQuery.removeEventListener('change', notify);
+        mediaQuery = null;
+    }
+    dotnetRef = null;
+}

--- a/docs/superpowers/specs/2026-04-27-aurora-mobile-design.md
+++ b/docs/superpowers/specs/2026-04-27-aurora-mobile-design.md
@@ -1,7 +1,7 @@
 # Aurora Mobile — Design Spec
 
 **Status:** Approved for implementation. Aurora desktop redesign fully shipped 2026-04-26/27 (PRs #31–#34).
-**Source of truth for visuals:** `D:\Web\jame581\design_handoff_aurora\aurora-mobile.jsx` (in-app), `aurora-mobile-landing.jsx` (landing), and the "Mobile (iOS) screens" section of the handoff `README.md`.
+**Source of truth for visuals:** the Aurora handoff bundle (Claude Design output) — `aurora-mobile.jsx` (in-app), `aurora-mobile-landing.jsx` (landing), and the "Mobile (iOS) screens" section of `README.md`. The bundle is a local design artifact kept outside the repo (the originating workstation has it at `D:\Web\jame581\design_handoff_aurora\`); ask the project owner for a copy if you need to regenerate from source.
 **This document:** project-specific decisions the visual handoff does not specify, plus a brief on-ramp for the implementer.
 
 ---

--- a/docs/superpowers/specs/2026-04-27-aurora-mobile-design.md
+++ b/docs/superpowers/specs/2026-04-27-aurora-mobile-design.md
@@ -1,0 +1,282 @@
+# Aurora Mobile — Design Spec
+
+**Status:** Approved for implementation. Aurora desktop redesign fully shipped 2026-04-26/27 (PRs #31–#34).
+**Source of truth for visuals:** `D:\Web\jame581\design_handoff_aurora\aurora-mobile.jsx` (in-app), `aurora-mobile-landing.jsx` (landing), and the "Mobile (iOS) screens" section of the handoff `README.md`.
+**This document:** project-specific decisions the visual handoff does not specify, plus a brief on-ramp for the implementer.
+
+---
+
+## 1. Scope
+
+**In:** Mobile-responsive treatment of every existing in-app screen (Dashboard, Time tracker, Tracked tasks, Calendar, Projects, Profile, Trash) plus the landing page. New `MobileTabBar` (bottom 5-slot nav with center FAB) replaces the desktop sidebar at ≤768px. New `MobileMoreSheet` (slide-up overflow) for off-tab-bar destinations (Profile, Calendar, Trash, Log out). New `DayCalendar` component for the mobile calendar's day-view-with-week-strip layout.
+
+**Out:**
+- New backend endpoints, DTO changes, EF migrations.
+- New design tokens. Mobile reuses every existing token from `aurora.css`; only sizing values shrink.
+- The settings list card from `aurora-mobile.jsx`'s Profile screen (Notifications / Appearance / Goal per week / Export data). Skipped per Q3 — three of four rows would be visual-only and the fourth (Goal) requires a backend column. Defer until at least one row has real backing.
+- The mobile-specific Dashboard topbar copy ("Hi, Jan / Friday April 24"). Existing route-driven topbar copy stays — small enough cost to keep one code path.
+- Real GitHub star count on the landing's "Star on GitHub · 1.2k" link (already deferred from Aurora work).
+- Dark-mode toggle, notification system, configurable weekly goal, data export — none of those are introduced; mobile just doesn't add new UI for them.
+
+---
+
+## 2. Architecture
+
+### Viewport detection
+
+A new `ViewportService` (scoped, registered in `Program.cs`) is the single source of truth for mobile-mode state.
+
+**Mechanism.** On first render, `MainLayout` calls a small ES module at `wwwroot/js/viewport.js` that:
+
+1. Reads `window.matchMedia('(max-width: 768px)').matches` once and pushes to .NET via a `[JSInvokable]` callback.
+2. Subscribes to that media query's `change` event and pushes updates.
+
+`ViewportService` exposes `bool IsMobile` and an `event Action OnChanged`. `MainLayout` subscribes, rerenders on change, and re-publishes via:
+
+```razor
+<CascadingValue Value="IsMobile" Name="IsMobile">
+  …
+</CascadingValue>
+```
+
+Components that need to branch on viewport read it via `[CascadingParameter(Name = "IsMobile")] bool IsMobile`. Most components don't need it — only `MainLayout`, `Topbar`, `TrackedTaskScheduler` (calendar host), and `MobileTabBar` itself.
+
+The breakpoint `768px` matches the handoff. Single source of truth: `viewport.js` hardcodes the query; nothing else queries `matchMedia`.
+
+### Component layout
+
+| File | Status | Purpose |
+|---|---|---|
+| `Services/ViewportService.cs` | new | matchMedia → .NET bridge |
+| `wwwroot/js/viewport.js` | new | small ES module, registered once |
+| `Shared/MainLayout.razor` + `.razor.css` | edit | `IsMobile` cascade, conditional sidebar/tab-bar rendering |
+| `Shared/Topbar.razor` + `.razor.css` | edit | mobile sizing via media query, mobile-only avatar trigger for `MobileMoreSheet` |
+| `Shared/MobileTabBar.razor` + `.razor.css` | new | fixed-bottom 5-slot tab bar with FAB |
+| `Shared/MobileMoreSheet.razor` + `.razor.css` | new | slide-up sheet for Profile / Calendar / Trash / Log out |
+| `Services/MobileSheetService.cs` | new | scoped service exposing `Show()` / `Hide()` so Topbar's avatar can open the sheet |
+| `Components/Scheduler/DayCalendar.razor` + `.razor.css` | new | mobile day-view calendar with week-strip selector |
+| `Pages/TrackedTasks/TrackedTaskScheduler.razor` | edit | render `DayCalendar` if `IsMobile`, `WeekCalendar` otherwise |
+| Per-screen `.razor.css` | edit | mobile reflow rules per Section 4 |
+| `wwwroot/css/landing.css` | edit | extended `@media (max-width: 768px)` block |
+| `Shared/NavMenu.razor` + `.razor.css` | unchanged | sidebar gated off at the layout level, not from inside |
+| `wwwroot/index.html` | unchanged | boot splash already responsive |
+
+### What stays untouched
+
+Server, all controllers + DTOs, all repositories, EF migrations, Identity Razor Pages (login/register/manage all share the Aurora identity layout from PR #33; verify they look right at narrow viewports as part of smoke testing). All existing modals (`AddTrackedTask`, `AddTrackedTaskForm`, `EditTrackedTaskForm`, `AddProject`) — they already render in `RadzenDialog` which handles narrow viewports reasonably.
+
+---
+
+## 3. Layout shell on mobile
+
+### `MainLayout.razor`
+
+Authenticated branch:
+
+```razor
+<CascadingValue Value="IsMobile" Name="IsMobile">
+  <AuthorizeView>
+    <Authorized>
+      <div class="aurora-app @(IsMobile ? "is-mobile" : "")">
+        @if (!IsMobile)
+        {
+          <NavMenu />
+        }
+        <main class="aurora-main">
+          <Topbar />
+          <article class="aurora-content">@Body</article>
+          @if (IsMobile)
+          {
+            <MobileTabBar />
+            <MobileMoreSheet />
+          }
+        </main>
+      </div>
+    </Authorized>
+    <NotAuthorized>@Body</NotAuthorized>
+  </AuthorizeView>
+</CascadingValue>
+<RadzenDialog />
+<RadzenNotification />
+```
+
+Unauthenticated branch (landing) keeps its bare `@Body` from phase 2 — the mobile landing reflow is pure CSS inside `landing.css`.
+
+### `Topbar.razor`
+
+Existing markup stays. Two changes:
+
+1. **CSS sizing under `@media (max-width: 768px)`:** title 22px, subtitle 12.5px / single-line ellipsis, padding `6px 20px 14px`. Search bar + ⌘K hint chip hidden (the search is non-functional anyway). Quick Add button **also hidden** on mobile — the bottom tab bar's center FAB handles "+" actions everywhere, so a duplicate topbar button would just be visual noise.
+2. **Mobile-only avatar trigger:** rendered only when `IsMobile` is true. Sits as the sole trailing element. 38×38 round, gradient background `linear-gradient(135deg, var(--accent), #9D7CFF)`, white initials. Click → `MobileSheetService.Show()`.
+
+Topbar copy (route-driven titles + subtitles) stays the same on mobile.
+
+### `MobileTabBar.razor`
+
+Fixed-bottom positioning with 16px horizontal margin. Glass surface: `backdrop-filter: blur(20px) saturate(180%)`, white at 85% opacity, hairline border, soft shadow `0 12px 30px -12px rgba(20, 18, 40, .18)`. `padding-bottom: env(safe-area-inset-bottom, 0)` for iOS home indicator.
+
+Layout: 5-column grid. Order: Home · Tracker · **+** FAB · Tasks · Projects.
+
+- **Standard tab item.** Icon (21px, stroke 1.8) + label (10px / 500 / letter-spacing -0.1). Active = `var(--accent)` foreground. Inactive = `var(--text-mu)`. No background change.
+- **Center FAB.** 44×44 rounded-rect (radius 14), `linear-gradient(135deg, var(--accent), #8B6FFF)`, white plus icon (22px, stroke 2.2), `0 8px 18px -4px rgba(91, 91, 245, .55)` shadow, `margin-top: -14px` so it pops above the bar. No label. Tap → `DialogService.OpenAsync<AddTrackedTask>` (same as desktop Quick Add).
+
+Active-tab detection mirrors `NavMenu.IsActive` — strip query + fragment, normalize trailing slash, prefix-match against the route. Routes:
+- Home → `/`
+- Tracker → `/timetracker`
+- Tasks → `/trackedtasks`
+- Projects → `/projectmanager`
+
+`backdrop-filter` fallback for browsers lacking support: solid `var(--surface)` at 95% opacity. Use the standard `@supports not (backdrop-filter: blur(1px))` guard.
+
+The 100px content tail (added via `.aurora-content` mobile padding-bottom) prevents the tab bar from covering the last row of any list.
+
+### `MobileMoreSheet.razor`
+
+Hidden by default (`display: none`), shown when `MobileSheetService.IsOpen` is true. Slides up from the bottom of the viewport with a 200ms ease-out transform, dim full-screen backdrop above the tab bar.
+
+Rows (in order, each tappable, each dismisses sheet on tap):
+1. Profile → `/profile`
+2. Calendar → `/scheduler`
+3. Trash → `/trash`
+4. Log out → existing `SignOutSessionStateManager.SetSignOutState` + `Navigation.NavigateTo("authentication/logout")`
+
+Backdrop tap or row tap closes. Sheet has its own scoped CSS for the row layout (icon + label + chevron + hairline divider).
+
+### `MobileSheetService`
+
+Tiny scoped service:
+
+```csharp
+public class MobileSheetService
+{
+    public bool IsOpen { get; private set; }
+    public event Action? OnChange;
+
+    public void Show()
+    {
+        IsOpen = true;
+        OnChange?.Invoke();
+    }
+
+    public void Hide()
+    {
+        IsOpen = false;
+        OnChange?.Invoke();
+    }
+}
+```
+
+`Topbar.razor` injects it and calls `Show()`. `MobileMoreSheet.razor` subscribes to `OnChange` and rerenders.
+
+---
+
+## 4. Per-screen mobile reflows
+
+All reflows are scoped CSS inside the existing component's `.razor.css` (or the page-level `.razor.css`). No markup changes except the calendar host.
+
+| Screen | Reflow | Selector / approach |
+|---|---|---|
+| **Dashboard** | Hero card full-width, 22 padding, hero number 46px (down from 56). Stat row → 2-up. Bar chart full-width, 130px tall, 6 bars max-width 32px. Donut full-width below. Recent activity full-width. | Existing breakpoint at 1100px tightens; add ≤768 block |
+| **TimeTracker** | Big timer 60px, centered. Action row centers with `justify-content: center`, gap 18: 50 reset · 78 play/pause · 50 edit. Project / Tags tiles drop to 2-up grid below the task tile. | `.aurora-tracker-card__top { flex-direction: column; align-items: stretch; }` plus action-row centering |
+| **TrackedTasks** | Filter bar collapses to single search input + primary `+` button. Drop the 3 ghost buttons (All projects / date range / Export). Day-group rows stack: name on top, project pill + time-range as a meta line, mono duration right-aligned. | Existing `≤900px` rule extends; ghost buttons get `display: none` at ≤768 |
+| **Projects** | Card grid → 1-column. Card pad 16. Sparkline 28px tall (down from 36). | Existing `≤720px` rule extends with sparkline tweak |
+| **Profile** | 4-stat grid → 2×2. Identity row: avatar + meta stack vertically; ghost "Log out" + primary "Edit profile" stay side-by-side, full-width. | `grid-template-columns: repeat(2, 1fr)` + flex-direction column on header |
+| **Trash** | Two cards stack. Each row: name on top, deleted-date / days-remaining as a meta line below, action buttons stacked or wrapped. | `.aurora-trash-row { grid-template-columns: 1fr; gap: 8px; }` |
+| **Calendar** | Replace `WeekCalendar` with `DayCalendar` based on `IsMobile`. | Markup change in `TrackedTaskScheduler.razor` (only structural change of all reflows) |
+
+### `DayCalendar.razor`
+
+New component. ~150 lines of Razor + scoped CSS.
+
+**Inputs (matches `WeekCalendar`'s contract):**
+- `IList<TrackedTaskDto> Tasks` — full week's tasks
+- `EventCallback<DateTime> OnEmptyClick`
+- `EventCallback<TrackedTaskDto> OnEventClick`
+- `DateTime WeekStart` — for the 7-day strip selector
+
+**Internal state:** `DateTime SelectedDay` (defaults to today, falls back to `WeekStart` if today isn't in this week).
+
+**Layout:**
+1. **Week strip** — white card (pad 8, radius 18), 7 buttons across. Each button 8px vertical padding. Weekday label (10px uppercase) above day number (17px / 600). Active day = `var(--accent)` background, white text, accent glow shadow. Tap to switch `SelectedDay`.
+2. **Day header** — left: "Today, Apr 24" + `N tasks · X.Xh` muted. Right: segmented `Day` / `Week` / `Month` (Day active). Week and Month buttons disabled with "Coming soon" tooltips, matching the desktop's deferred mode handling.
+3. **Day grid card** (pad 0). 2-column grid: 44px hours column (8–18, mono labels) + 1fr events column. Hour rows 52px tall, hairline top borders. Events absolute-positioned, left/right 6px, top = `(hour - 8) * 52`, height = `max(duration_hours * 52, 28)`. Style: `background: <color>22; border-left: 3px solid <color>; border-radius: 8;`. Inner: title (11.5px / 500) + mono time-range (10px).
+4. **Current-time line** (today only) — 2px tall danger line at the right top offset, with a 10px round dot on the left edge.
+
+Click an empty cell → `OnEmptyClick` with the cell's `DateTime` (existing add modal). Click an event → `OnEventClick(task)` (existing edit modal).
+
+`DayCalendar` ticks every 60s like `WeekCalendar` (current-time line refresh) and disposes its timer the same way.
+
+`TrackedTaskScheduler.razor` host updates:
+
+```razor
+@if (IsMobile)
+{
+    <DayCalendar WeekStart="WeekStart" Tasks="WeekTasks"
+                 OnEmptyClick="OnEmptyCellClicked" OnEventClick="OnEventClicked" />
+}
+else
+{
+    <WeekCalendar WeekStart="WeekStart" Tasks="WeekTasks"
+                  OnEmptyClick="OnEmptyCellClicked" OnEventClick="OnEventClicked" />
+}
+```
+
+Both consume the same `WeekTasks` list and the same prev/next/today navigation.
+
+**Page toolbar on mobile.** The desktop's page-level toolbar (prev/today/next + range label + segmented Day/Week/Month + "Add task" primary button) is too cramped on a 402px viewport. On mobile, the page toolbar hides the segmented control and the "Add task" button — both responsibilities move into `DayCalendar` (segmented control in its day header) and the FAB (add-task) respectively. Prev/today/next + range label stay, since they navigate by week and the week strip alone doesn't cover that.
+
+---
+
+## 5. Mobile landing
+
+Pure CSS reflow inside `wwwroot/css/landing.css`. No new components. Existing `LandingNav`, `LandingHero`, `LandingFeatures`, `LandingOss`, `LandingFooter` stay.
+
+The current `landing.css` already has `@media (max-width: 1024px)` (hero stacks, features grid → 1col, OSS card stacks) and `@media (max-width: 640px)` (nav links collapse, type shrinks). Extend with a `@media (max-width: 768px)` block matching `aurora-mobile-landing.jsx`:
+
+- **Top nav.** Hide `Features`, `Open source`, and `GitHub` text links. Keep wordmark + "Log in" pill. Drop the "Get started — free" CTA — the hero CTA carries it.
+- **Hero.** H1 to 42px / weight 600 / letter-spacing -1.6 (down from 76). Lead paragraph 15px. Stacked full-width CTAs: primary "Register and start tracking →" first, then ghost "Star on GitHub · 1.2k". Trust strip stays single-row at 12.5px or wraps.
+- **Hero card mock.** Padding 22, big mono timer 46px (down from 64), inset stat panel keeps the 12-bar sparkline.
+- **Features.** Already stacks at 1024px; verify mini visuals still render at narrow widths.
+- **OSS card.** Padding 24, headline wraps to 2 lines, side-by-side full-width buttons.
+- **Footer.** Centered: mark + copyright row, links underneath.
+
+Don't render the iPhone bezel — handoff says explicitly that's a prototype-only frame.
+
+---
+
+## 6. Build sequence
+
+Single feature branch `feature/aurora-mobile` off `develop`. One PR back to `develop`. ~12–14 commits, each leaves the app buildable and the desktop experience unaffected:
+
+1. **Spec doc** — commit this design doc.
+2. **Viewport plumbing** — `Services/ViewportService.cs`, `wwwroot/js/viewport.js`, register in `Program.cs`. Nothing consumes it yet.
+3. **MainLayout cascade** — add `[CascadingValue]`, subscribe to `ViewportService`. Sidebar still always renders; empty `MobileTabBar.razor` and `MobileMoreSheet.razor` stubs created so layout references compile.
+4. **MobileTabBar implementation** — full glass tab bar markup + scoped CSS, FAB wired to `DialogService.OpenAsync<AddTrackedTask>`. Active-tab logic. Still hidden, no breakpoint gate.
+5. **MobileMoreSheet implementation** — slide-up sheet markup + scoped CSS, `MobileSheetService` registered.
+6. **Mobile shell wiring** — `MainLayout` gates `<NavMenu />` on `!IsMobile`, renders `<MobileTabBar />` + `<MobileMoreSheet />` when `IsMobile`. Topbar adds mobile avatar trigger + media-query reflow. App actually switches mode at 768px after this commit.
+7. **DayCalendar component** — new component + scoped CSS. `TrackedTaskScheduler.razor` host renders `<DayCalendar />` if `IsMobile`, `<WeekCalendar />` otherwise.
+8. **Per-screen reflow CSS** — one commit per screen for clean diffs:
+   - 8a. Dashboard
+   - 8b. TimeTracker
+   - 8c. TrackedTasks
+   - 8d. Projects
+   - 8e. Profile
+   - 8f. Trash
+9. **Mobile landing reflow** — extend `landing.css` `@media (max-width: 768px)` block per Section 5.
+10. **Smoke + cleanup pass** — verify boot splash, login, register on mobile viewport (Identity pages already responsive but worth confirming). Touch-target audit — every interactive element ≥ 44px square. Remove dead CSS uncovered.
+
+---
+
+## 7. Open questions / non-goals
+
+- **Settings list card on Profile** — not in v1. Defer to a future PR when at least one row (likely Goal) has real backend backing.
+- **Real GitHub star count** — already deferred from Aurora work; out of scope here.
+- **Topbar mobile-specific copy on Dashboard** ("Hi, Jan / Friday April 24") — keep desktop copy; not worth a forked code path for v1.
+- **iOS-style status-bar safe area at the top** — `env(safe-area-inset-top)` applied only to the tab bar's bottom (`safe-area-inset-bottom`). Top safe-area is handled by browser chrome on PWAs; if added later, attach to `.aurora-id-top` and `.aurora-topbar`.
+- **Tablet treatment** — anything between 769–1023px gets the desktop layout. The handoff doesn't specify a tablet breakpoint, so we don't either. Revisit if it looks wrong.
+
+---
+
+## 8. Done
+
+After this merges, every screen reflows below 768px to a coherent mobile experience: bottom tab bar, mobile-sized topbar, full-width cards, day-view calendar, slide-up overflow for off-bar destinations. Desktop experience unchanged. No backend changes. No new tokens.


### PR DESCRIPTION
## Summary

Mobile-responsive treatment of every Aurora screen plus the landing page. New bottom tab bar replaces the sidebar at ≤768px, plus a slide-up sheet for off-tab-bar destinations (Profile / Calendar / Trash / Log out) and a new \`DayCalendar\` component for the mobile day-view-with-week-strip layout. Spec: \`docs/superpowers/specs/2026-04-27-aurora-mobile-design.md\`.

## What landed (10 commits)

1. **\`76710cf\`** — design spec doc.
2. **\`a77f0a6\`** — \`ViewportService\` + \`wwwroot/js/viewport.js\` matchMedia bridge.
3. **\`e9c2240\`** — \`MainLayout\` cascades \`IsMobile\`, subscribes to \`ViewportService\`. Empty stubs for \`MobileTabBar\`/\`MobileMoreSheet\`.
4. **\`50b9085\`** — \`MobileTabBar\` glass nav with FAB. Active-tab logic, \`backdrop-filter\` fallback for unsupported browsers.
5. **(part of 6a1ebc4)** — \`MobileSheetService\` + \`MobileMoreSheet\` slide-up panel for Profile/Calendar/Trash/Log out.
6. **\`6a1ebc4\`** — Mobile shell wired: sidebar \`@if (!IsMobile)\`, tab bar + sheet \`@if (IsMobile)\`. Topbar swaps search+Quick-Add for the avatar trigger on mobile, mobile media query shrinks title/subtitle.
7. **\`b7…\`** — \`DayCalendar\` component + scoped CSS. Host \`TrackedTaskScheduler\` renders \`DayCalendar\` on mobile, \`WeekCalendar\` on desktop. Mobile drops the page-level segmented control + 'Add task' button (FAB and the in-card segmented control cover those).
8. **\`f34723b\`** — Mobile reflow CSS for Dashboard, TimeTracker, TrackedTasks, Projects, Profile, Trash. Single commit (each is a small \`@media (max-width: 768px)\` block).
9. **\`3fc524d\`** — Mobile landing reflow per \`aurora-mobile-landing.jsx\` (single \`@media (max-width: 768px)\` block in \`landing.css\`).

## Out of scope (per spec)

- **Settings list card on Profile** (Notifications / Appearance / Goal / Export) — three of four rows would be visual-only and the fourth needs a backend column. Defer until at least one row has real backing.
- **Real GitHub star count** on the landing — already deferred from Aurora work.
- **Mobile-specific Dashboard topbar copy** ("Hi, Jan / Friday April 24") — reuses existing route-driven copy. Not worth a forked code path.
- **Top safe-area inset** — only \`safe-area-inset-bottom\` applied (tab bar). Add later if PWA full-screen mode needs it.
- **Tablet breakpoint (769–1023px)** — keeps the desktop layout. Spec doesn't define a tablet treatment.

## Test plan

- [x] \`dotnet build Timinute.sln\` — succeeds
- [x] \`dotnet test Timinute.sln\` — 96 server tests pass (no regressions)
- [ ] Open the running app, narrow the window to ≤768px → sidebar hides, glass tab bar appears at the bottom
- [ ] Tap topbar avatar → slide-up sheet shows Profile / Calendar / Trash / Log out
- [ ] Tap tab bar Home / Tracker / Tasks / Projects → routes correctly, active state lights up
- [ ] Tap center FAB → \`AddTrackedTask\` modal opens
- [ ] Calendar route → \`DayCalendar\` with 7-day strip; tap a day to switch; tap an event opens edit modal; tap an empty cell opens add modal; current-time line on today
- [ ] Resize from 1024px → 769px → 768px → 480px; reflows happen smoothly with no layout breaks
- [ ] Sign out, narrow viewport, visit \`/\` → mobile landing renders correctly: only wordmark + Log in pill, stacked CTAs, single-column features
- [ ] Verify \`backdrop-filter\` fallback in a browser without support (or with Chrome's "Disable HW acceleration") — tab bar shows solid 95% opacity surface