### PR TITLE
docs: README rewrite + plans audit (v2.0 / Aurora state)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,84 @@
 # Timinute
+
 [![Build & Test](https://github.com/jame581/Timinute/actions/workflows/build_test.yml/badge.svg)](https://github.com/jame581/Timinute/actions/workflows/build_test.yml)
 
-The free time tracker and time tracking software. Timinute is a time tracker and timesheet app that lets you track work hours across projects.
-The application serves as a demonstration of the possibilities of the new Blazor technology. Allows you to track time and task. Duende IdentityServer is used to manage users.
+The free, open-source time tracker that respects your minutes. Track work hours across projects, see exactly where your time goes, and get clear weekly overviews — all in a self-hostable Blazor WebAssembly app.
 
-### Prerequisites
+Originally a demo of modern Blazor; now fully redesigned around the **Aurora** visual system (v2.0) with a tokenized design system, hand-built SVG charts, a custom calendar, and full mobile-responsive treatment.
 
-Software what you need is:
+## Highlights
 
-* [Visual Studio 2022 (Version 17 or better)](https://visualstudio.microsoft.com/)
-* [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet)
-* [Docker Desktop (Is used for SQL Database)](https://www.docker.com/get-started) 
+- **Time tracker** with a real-time stopwatch, session-storage persistence across reload, and undo on delete.
+- **Calendar** — desktop week view with a current-time line, mobile day view with a 7-day strip selector. Click an empty cell to add, click an event to edit.
+- **Projects** with user-picked colors, monthly stats, and per-project sparklines.
+- **Dashboard** — gradient hero stat card, top-project + last-month tiles, hand-built SVG bar chart and donut, recent activity list.
+- **Trash** — 30-day soft-delete recovery for projects and tasks, cascade-restore on Project, background hard-purge service.
+- **Search + filter + export** — date range, project, name, task-count filters; CSV and Excel exports.
+- **Identity** — Duende IdentityServer for auth (JWT for the API, cookie for Identity UI), Basic/Admin roles, lockout, registration via Razor Pages.
+- **Mobile responsive** — bottom glass tab bar with FAB, slide-up overflow sheet, full reflow at ≤768px.
+- **Accessibility** — `prefers-reduced-motion` honored, `aria-current` on active nav, focus-visible outlines, modal sheet semantics.
 
-That's it :)
+## Tech stack
+
+.NET 10 · Blazor WebAssembly (hosted) · EF Core 10 · SQL Server · Duende IdentityServer · Radzen.Blazor (dialogs/notifications only — design system is custom Aurora) · xUnit + Moq + EF InMemory.
+
+## Prerequisites
+
+- [Visual Studio 2022 (17.x or newer)](https://visualstudio.microsoft.com/) or another .NET 10 IDE
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet)
+- [Docker Desktop](https://www.docker.com/get-started) — used for the local SQL Server 2025 container
 
 ## Getting Started
 
-First step install prerequisites software, then clone repository, setup SQL database, build solution, then run database migrations and finally run solution.
+```powershell
+# 1. clone
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
 
-* Clone repository
-* Go to folder `Scripts`
-  * run script `SetupDockerSql.ps1` (creates SQL Server 2025 container on port 44555)
-  * run script `MigrateDatabase.ps1` (applies EF Core migrations)
-* Build & run solution
+# 2. start a local SQL Server 2025 container on port 44555
+.\scripts\SetupDockerSql.ps1
+
+# 3. apply EF Core migrations
+.\scripts\MigrateDatabase.ps1
+
+# 4. run the app (server hosts the WASM client)
+dotnet run --project Timinute/Server/Timinute.Server.csproj
+```
+
+Default URLs: <https://localhost:7047> / <http://localhost:5047>. Swagger lives at `/swagger`.
+
+Seeded test users (passwords are intentionally trivial — local dev only):
+
+| Email | Role |
+|---|---|
+| test1@email.com | Basic |
+| test2@email.com | Basic |
+| test3@email.com | Basic |
+
+## Project layout
+
+```
+Timinute/
+  Server/         ASP.NET Core Web API + Identity + IdentityServer
+  Client/         Blazor WebAssembly SPA (Aurora design system)
+  Shared/         DTOs shared between client and server
+  Server.Tests/   xUnit + Moq + EF InMemory
+docs/superpowers/
+  specs/          Per-feature design specs
+  plans/          Active plans
+  plans/done/     Shipped plans, kept for history
+```
+
+## Roadmap
+
+See [`docs/superpowers/plans/feature-roadmap.md`](docs/superpowers/plans/feature-roadmap.md) for the current feature set, P1/P2 backlog, and tech-debt list. Active design specs live alongside in `docs/superpowers/specs/`.
 
 ## Author
 
-* **Jan Mesarč** - *Creator* - [jame581](https://jame581.azurewebsites.net/)
+**Jan Mesarč** — *Creator* — [jame581](https://github.com/jame581)
 
-Do you like this project and want me support? Great! I really appreciate it and makes me very happy if you buy [Buy Me A Coffee](https://www.buymeacoffee.com/jame581).
+If Timinute is useful to you, [Buy Me A Coffee](https://www.buymeacoffee.com/jame581) ☕.
 
-## Video
+## License
 
-https://user-images.githubusercontent.com/21112138/217609228-ac3dfdb4-3f97-4771-aff1-ee98917f5547.mp4
-
-## Screenshots
-![Dashboard](https://user-images.githubusercontent.com/21112138/154512704-0680fe51-8dfa-4012-9d4b-bada6592c3fa.png)
-![TrackedTasks](https://user-images.githubusercontent.com/21112138/154512705-d13dcf63-f5ca-49b3-8897-9001f37c4cde.png)
-![Calendar](https://user-images.githubusercontent.com/21112138/154512708-2544afc4-0065-47ab-ac72-25f34bd46a63.png)
+MIT — see [LICENSE](LICENSE).

--- a/docs/superpowers/plans/done/2026-03-31-timinute-modernization.md
+++ b/docs/superpowers/plans/done/2026-03-31-timinute-modernization.md
@@ -1,5 +1,7 @@
 # Timinute Modernization Plan
 
+> **Status:** ✅ Shipped — merged via PR #25 on 2026-04-01. Phase 1 (.NET 10 upgrade + Duende IdentityServer migration) is in `develop`. Phases 2 (UI redesign) and beyond evolved into the Aurora redesign tracked under separate specs in `docs/superpowers/specs/2026-04-26-*` and `2026-04-27-*`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Upgrade Timinute from .NET 8 to .NET 10, update all packages, verify functionality, expand test coverage, redesign UI, and plan new features.

--- a/docs/superpowers/plans/done/2026-04-01-advanced-filtering.md
+++ b/docs/superpowers/plans/done/2026-04-01-advanced-filtering.md
@@ -1,5 +1,7 @@
 # Advanced Filtering Implementation Plan
 
+> **Status:** ✅ Shipped — merged via PR #30 on 2026-04-01. `[HttpGet("search")]` endpoints exist on both `TrackedTaskController` and `ProjectController` with date-range, project, name, and task-count filters.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add search/filter endpoints for tracked tasks and projects with date range, project, name search, and task count filters.

--- a/docs/superpowers/plans/done/2026-04-01-data-export.md
+++ b/docs/superpowers/plans/done/2026-04-01-data-export.md
@@ -1,5 +1,7 @@
 # Data Export Implementation Plan
 
+> **Status:** ✅ Shipped — merged via PR #27 on 2026-04-01. `Timinute/Server/Controllers/ExportController.cs` exposes CSV + Excel endpoints for tasks, project summaries, and monthly analytics.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add CSV and Excel export endpoints for tracked tasks, project summaries, and monthly analytics.

--- a/docs/superpowers/plans/done/2026-04-01-p0-validation-authorization.md
+++ b/docs/superpowers/plans/done/2026-04-01-p0-validation-authorization.md
@@ -1,5 +1,7 @@
 # P0: Data Validation & Authorization Fixes — Implementation Plan
 
+> **Status:** ✅ Shipped — merged via PR #26 on 2026-04-01. `MinDurationAttribute` lives at `Timinute/Shared/Validators/MinDurationAttribute.cs`; ownership checks and DTO Data Annotations are in place across both controllers.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Fix authorization gaps on GET endpoints and add input validation to all create/update DTOs.

--- a/docs/superpowers/plans/done/2026-04-01-utc-normalization.md
+++ b/docs/superpowers/plans/done/2026-04-01-utc-normalization.md
@@ -1,5 +1,7 @@
 # UTC Normalization: DateTime → DateTimeOffset Implementation Plan
 
+> **Status:** ✅ Shipped — merged via PR #28 on 2026-04-01. All `TrackedTask` date columns and DTO properties use `DateTimeOffset`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Migrate all date/time handling from `DateTime` to `DateTimeOffset` to eliminate timezone ambiguity.

--- a/docs/superpowers/plans/done/2026-04-19-soft-delete.md
+++ b/docs/superpowers/plans/done/2026-04-19-soft-delete.md
@@ -1,5 +1,7 @@
 # Soft Delete Implementation Plan
 
+> **Status:** ✅ Shipped — merged into `develop` via `feature/soft-delete` on 2026-04-20 (merge commit `271ffd7`). `DeletedAt` column + EF global query filter, repository methods, cascade on Project delete, Trash page with undo toast, and `TrashPurgeService` background hard-purger are all live.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make `DELETE` on Project and TrackedTask recoverable for 30 days via a `DeletedAt` timestamp + EF global query filter, with cascade on Project delete, a Trash page + undo toast in the Blazor client, and a background service that hard-purges expired rows.

--- a/docs/superpowers/plans/done/ui-redesign-spec.md
+++ b/docs/superpowers/plans/done/ui-redesign-spec.md
@@ -1,5 +1,12 @@
 # Timinute UI Redesign Specification
 
+> **Status:** ⚠️ Superseded — this early scoping doc was replaced by the Aurora redesign specs and is preserved here for historical context only. The actual implemented design is documented across:
+> - `docs/superpowers/specs/2026-04-26-aurora-redesign-design.md` — phase 1 (in-app shell + 5 screens + Profile + Trash)
+> - `docs/superpowers/specs/2026-04-26-aurora-landing-design.md` — phase 2 (landing page)
+> - `docs/superpowers/specs/2026-04-27-aurora-mobile-design.md` — mobile responsive treatment
+>
+> Aurora shipped via PRs #31 / #32 / #33 / #34 / #35 between 2026-04-26 and 2026-04-27.
+
 ## Current State Summary
 
 - Blazor WASM with Radzen 10.x + Bootstrap 5

--- a/docs/superpowers/plans/feature-roadmap.md
+++ b/docs/superpowers/plans/feature-roadmap.md
@@ -1,36 +1,50 @@
 # Timinute Feature Roadmap
 
+_Last reviewed: 2026-04-27 — after Aurora mobile (PR #35) merged into `develop`._
+
 ## Current Feature Set
 
-- **Auth:** Registration, JWT auth via Duende IdentityServer, roles (Basic/Admin), lockout
-- **Projects:** Full CRUD, user-scoped, pagination
-- **Task Tracking:** Full CRUD, real-time stopwatch timer, session storage persistence, manual entry
-- **Calendar:** Scheduler view (Day/Week/Month) with add/edit forms
-- **Analytics:** Project work time, monthly aggregation, top project stats, donut + column charts
-- **Data Access:** Generic repository pattern with paging, filtering, dynamic LINQ ordering
+### Foundation
+- **.NET 10** Blazor WebAssembly hosted app (Server + Client + Shared).
+- **Auth:** Duende IdentityServer, registration via server-side Razor Page, JWT for the API, cookie scheme for Identity UI, Basic/Admin roles, lockout.
+- **Data access:** Generic repository + factory pattern with paging, filtering, dynamic LINQ ordering, EF global query filter for soft delete.
+- **Time/date:** all date columns + DTOs use `DateTimeOffset` (UTC normalization complete).
+- **Validation:** Data Annotations on Create/Update DTOs incl. `MinDuration` for `TimeSpan`, `EndDate > StartDate` checks, hex-color regex on `Project.Color`. Ownership checks on every controller action.
 
-## P0: Must-Have (Security & Data Integrity)
+### Core domain
+- **Projects:** Full CRUD with user-defined Color, user-scoped, search + filter endpoint, paging.
+- **Time tracking:** Full CRUD, real-time stopwatch with seconds-in-accent live timer, session-storage persistence across reload, manual entry, undo toast on delete.
+- **Calendar:** Custom Aurora `WeekCalendar` (desktop, 7-day grid + current-time line) and `DayCalendar` (mobile, 7-day strip + day grid). Tap-to-add / tap-to-edit via existing modals.
+- **Soft delete + Trash:** 30-day recovery for projects + tasks, cascade-restore on Project, `TrashPurgeService` background hard-purger.
+- **Analytics:** Project work time, monthly aggregation, top-project stats, hand-built SVG bar chart + donut on the dashboard.
+- **Search/filter:** `[HttpGet("search")]` on tasks (date range, project, name, task-count) and projects (name, min-task-count).
+- **Data export:** CSV + Excel for tasks, project summaries, monthly analytics (`ExportController`).
 
-| Feature | Description | Complexity |
-|---------|-------------|------------|
-| Data validation | Add Required/MaxLength/Range attributes to DTOs, validate EndDate > StartDate, duration > 0 | S |
-| Analytics optimization | Replace LINQ-to-Objects with DB-side queries (Dapper or raw SQL) for analytics endpoints | M |
-| Timer edge cases | Handle overlapping tasks, impossible durations, better session persistence | S |
-| Soft delete | Add IsArchived flag to tasks/projects instead of hard delete, with recovery | M |
+### UI / UX (Aurora design system, v2.0)
+- **Design tokens** in `aurora.css` — surfaces, sidebar, accent (indigo), category palette, radii, shadows, fonts (Geist + Geist Mono).
+- **In-app shell:** sidebar (desktop) / bottom tab bar with FAB (mobile) + slide-up overflow sheet for off-tab destinations.
+- **Aurora-skinned screens:** Dashboard, Time tracker, Tracked tasks, Calendar, Projects, Profile, Trash, Login, Register.
+- **Landing page:** redesigned hero with live decorative timer, feature grid, OSS CTA, terminal mock, footer.
+- **Boot splash:** Aurora-themed `index.html` first-paint shell.
+- **Responsive:** mobile breakpoint at ≤768px; landing also has a ≤480px tighter pass.
+- **Accessibility:** `prefers-reduced-motion` honored on the `aurora-pulse` animation, `aria-current="page"` on active nav, `:focus-visible` outlines on interactive elements, `aria-modal` + Escape-to-close on the mobile sheet.
 
-## P1: Should-Have (Productivity & UX)
+---
 
-| Feature | Description | Complexity | Dependencies |
-|---------|-------------|------------|--------------|
-| Data export | CSV/PDF export for tracked tasks and analytics | M | None |
-| Advanced filtering | Date range API filters, full-text search on task names, filter persistence | M | None |
-| Tags/Labels | Tag model with many-to-many Tag-Task relationship, UI for tagging | M | None |
-| Enhanced analytics | Custom date ranges, daily/weekly summaries, productivity trends | M | Analytics optimization |
-| Settings/Preferences | User profile page, timezone config, workday hours, dark mode preference | M | None |
-| Notifications | Idle time warnings, task reminders via SignalR or browser push | M | None |
+## Pending — P1 (Should-Have)
+
+| Feature | Description | Complexity | Notes |
+|---------|-------------|------------|-------|
+| Tags / Labels | Tag entity, many-to-many to TrackedTask, UI for tagging on tasks + filter by tag | M | The design has tag pills (`focus`, `backend`) on the time tracker visually, but they're hardcoded |
+| Settings / Preferences | User profile editable fields, configurable weekly goal (currently hardcoded `32h`), workday hours, dark-mode toggle | M | Mobile Profile spec deferred a settings list card waiting for this |
+| Dark-mode toggle | Tokens already defined in `aurora.css` `[data-theme="dark"]`; needs UI toggle + localStorage persistence + initial system-preference detection | S | Cheapest path: settings card row → `[data-theme]` attribute on `<html>` |
+| Configurable weekly goal | Backed-up column on `ApplicationUser`, settings UI, dashboard reads it | S | `Dashboard.razor:213` currently hardcodes `WeeklyGoalHours = 32` |
+| Enhanced analytics | Custom date ranges, daily/weekly summaries, productivity trends, push aggregation server-side | M | Dashboard stats currently load all user tasks client-side |
+| Notifications | Idle-time warnings, task reminders via SignalR or browser push | M | Topbar bell is hidden on desktop (visual placeholder only) waiting for this |
 | Time tracking enhancements | Pomodoro timer, time estimates/goals, break tracking | L | None |
+| Real GitHub star count | Replace landing's hardcoded `· 1.2k` with live fetch from GitHub API + localStorage cache | S | Deferred from Aurora work |
 
-## P2: Nice-to-Have (Advanced & Team)
+## Pending — P2 (Nice-to-Have)
 
 | Feature | Description | Complexity | Dependencies |
 |---------|-------------|------------|--------------|
@@ -38,36 +52,48 @@
 | Calendar integration | Google Calendar / Outlook sync | L | None |
 | Jira/GitHub integration | Link tasks to external tickets | L | Tags |
 | Audit logging | Track all changes for compliance | M | None |
-| Reporting suite | Scheduled email reports, custom report builder | L | Data export |
-| AI categorization | Automatic task categorization and productivity recommendations | L | Tags |
+| Reporting suite | Scheduled email reports, custom report builder | L | Already-shipped Data Export |
+| AI categorization | Automatic task categorization + productivity recommendations | L | Tags |
 
 ## Dependency Graph
 
 ```
-P0 (Security/Integrity) ── foundation for everything
-│
-├─ P1 (UX)
-│  ├─ Advanced Filtering (independent)
-│  ├─ Data Export (independent)
-│  ├─ Tags/Labels (independent)
-│  ├─ Settings (independent)
-│  ├─ Enhanced Analytics ← depends on Analytics optimization
-│  ├─ Notifications (independent)
-│  └─ Time Tracking Enhancements (independent)
-│
-└─ P2 (Advanced)
-   ├─ Team Workspaces ← depends on Settings
-   ├─ Integrations ← benefits from Tags
-   ├─ Reporting ← depends on Data Export
-   └─ AI Features ← depends on Tags
+Settings ─┬─ Dark-mode toggle (UI)
+          ├─ Configurable weekly goal
+          └─ Team workspaces (P2)
+
+Tags ─┬─ External-ticket integrations (P2)
+      └─ AI categorization (P2)
+
+Enhanced analytics — independent
+Notifications — independent
+Time tracking enhancements — independent
+Real GitHub star count — independent
 ```
 
-## Technical Debt to Address
+---
 
-- Constants class growing large — split per domain
-- Add request/response logging middleware
-- Add DB indexes on UserId, ProjectId for query performance
-- Add composite indexes for common analytics queries
-- Add unique constraint: project names per user
-- API versioning for future breaking changes
-- Extract common DataGrid logic into reusable component
+## Tech debt
+
+Status reviewed 2026-04-27.
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Constants class growing large — split per domain | open | `Server/Helpers/Constants.cs` mixes role + claim + magic strings |
+| Request/response logging middleware | open | Useful before production; not in critical path |
+| DB indexes on UserId, ProjectId | open | Repository queries filter by these on every endpoint |
+| Composite indexes for common analytics queries | open | Dashboard hits `GetTrackedTasks` per session |
+| Unique constraint: project names per user | open | DB-level constraint + 409 handling on duplicate create |
+| API versioning for future breaking changes | open | None of the API is published yet, so this is preparatory |
+| Extract common DataGrid logic | ✅ moot | Aurora replaced `RadzenDataGrid` with custom row layouts; no shared grid logic remains |
+| Move `<style>` blocks → scoped `.razor.css` | ✅ done | PR #34 |
+| `:has()` browser-support fragility on landing nav | ✅ done | PR #35 review fix — switched to `[href*="github.com"]` |
+| Per-render `IsActive` / `SelectedDayTasks` allocations | ✅ done | PR #35 review fix |
+
+---
+
+## How this doc is maintained
+
+- New features start as a spec in `docs/superpowers/specs/`, optionally with an implementation plan in `docs/superpowers/plans/`.
+- When a plan lands, move it to `docs/superpowers/plans/done/` and prepend a `Status:` block at the top with the merging PR + date.
+- Update this roadmap (P1/P2 tables + Tech-debt) in the same PR that completes a feature, so the file always reflects what's currently in `develop`.


### PR DESCRIPTION
## Summary

Updates the docs to match what's actually in \`develop\` after the Aurora redesign + mobile work shipped.

**README** — punchier copy that names the v2.0 Aurora visual system, a new Highlights section listing the actual shipped feature surface, tech-stack line, corrected setup paths (scripts are at repo root, not under \`Timinute/\`), project-layout block, roadmap link, and a license section. Drops the stale 2022 Bootstrap-era screenshot URLs.

**Plans audit** — every implementation plan currently in \`docs/superpowers/plans/\` is either done or superseded. Moved into \`done/\` subdirectory with a status header recording the merging PR + date:

| Plan | Status |
|---|---|
| \`2026-03-31-timinute-modernization\` | ✅ PR #25 (2026-04-01) |
| \`2026-04-01-p0-validation-authorization\` | ✅ PR #26 |
| \`2026-04-01-data-export\` | ✅ PR #27 |
| \`2026-04-01-utc-normalization\` | ✅ PR #28 |
| \`2026-04-01-advanced-filtering\` | ✅ PR #30 |
| \`2026-04-19-soft-delete\` | ✅ merged 2026-04-20 |
| \`ui-redesign-spec.md\` | ⚠️ Superseded by Aurora specs (PRs #31–#35) |

**\`feature-roadmap.md\` rewrite:**
- Current Feature Set reflects everything actually shipped (Foundation / Core domain / Aurora UI/UX) instead of the early-state list.
- P0 section dropped — all done.
- P1 keeps Tags, Settings, Dark-mode toggle, Configurable goal, Enhanced analytics, Notifications, Time-tracking enhancements, Real GitHub star count.
- P2 unchanged.
- Tech-debt table adds a Status column; marks DataGrid extraction moot, inline \`<style>\` extraction done (PR #34), and the \`:has()\` / per-render allocation fixes done (PR #35).
- \"How this doc is maintained\" footer codifies the spec → plan → done flow.

No code changes — build clean, no tests run (docs only).

## Test plan

- [ ] \`docs/superpowers/plans/\` now contains only \`feature-roadmap.md\` + the \`done/\` directory
- [ ] Each moved plan opens with a Status block at the top
- [ ] README's Getting Started block uses repo-root \`scripts/\` paths
- [ ] Roadmap's Current Feature Set matches what you see when you sign in