### PR TITLE
v2.1 extras: topbar theme toggle + mobile prefs list + Dashboard workday indicator

### DIFF
--- a/Timinute/Client/Components/Dashboard/Dashboard.razor
+++ b/Timinute/Client/Components/Dashboard/Dashboard.razor
@@ -191,6 +191,10 @@
 
     private void ComputeTodayStats()
     {
+        // Attribution by start time: a session that began yesterday at 23:30
+        // and ended after midnight is *not* counted toward today, even though
+        // most of its duration was today. Conventional choice for time
+        // trackers and matches how the weekly progress bar attributes too.
         var todayLocal = DateTimeOffset.Now.Date;
         var todayHours = AllUserTasks
             .Where(t => t.StartDate.LocalDateTime.Date == todayLocal)

--- a/Timinute/Client/Components/Dashboard/Dashboard.razor
+++ b/Timinute/Client/Components/Dashboard/Dashboard.razor
@@ -21,7 +21,7 @@
                 {
                     <span class="aurora-hero-card__chip">@(WeekDeltaPercent.Value >= 0 ? "+" : "")@WeekDeltaPercent.Value.ToString("0.#")% vs last week</span>
                 }
-                <span class="aurora-hero-card__sub">Goal @WeeklyGoal · @DaysLeft days left</span>
+                <span class="aurora-hero-card__sub">Goal @WeeklyGoal · @DaysLeft days left · Today @TodayDisplay</span>
             </div>
             <div class="aurora-hero-card__progress">
                 <div class="aurora-hero-card__progress-fill" style="width: @ProgressPct.ToString("0", System.Globalization.CultureInfo.InvariantCulture)%;"></div>
@@ -123,7 +123,11 @@
     // call fails so the dashboard's progress bar still renders something
     // sensible. Decimal so 7.5h-style preferences render correctly.
     private decimal WeeklyGoalHours = 32.0m;
+    private decimal WorkdayHoursPerDay = 8.0m;
+    private decimal TodayHours;
+
     private string WeeklyGoal => $"{WeeklyGoalHours:0.#}h";
+    private string TodayDisplay => $"{TodayHours:0.#}h / {WorkdayHoursPerDay:0.#}h target";
 
     private List<TrackedTaskDto> AllUserTasks = new();
     private List<TrackedTaskDto> RecentTasks = new();
@@ -165,13 +169,15 @@
             if (me?.Preferences != null)
             {
                 WeeklyGoalHours = me.Preferences.WeeklyGoalHours;
+                WorkdayHoursPerDay = me.Preferences.WorkdayHoursPerDay;
             }
         }
         catch
         {
-            // Keep the 32.0 fallback — progress bar still renders.
+            // Keep the 32.0 / 8.0 fallbacks — progress bar still renders.
         }
 
+        ComputeTodayStats();
         ComputeWeekStats();
         ComputeMonthlyChart();
         ComputeDonut();
@@ -181,6 +187,15 @@
             .OrderByDescending(t => t.StartDate)
             .Take(5)
             .ToList();
+    }
+
+    private void ComputeTodayStats()
+    {
+        var todayLocal = DateTimeOffset.Now.Date;
+        var todayHours = AllUserTasks
+            .Where(t => t.StartDate.LocalDateTime.Date == todayLocal)
+            .Sum(t => t.Duration.TotalHours);
+        TodayHours = (decimal)todayHours;
     }
 
     private void ComputeWeekStats()

--- a/Timinute/Client/Pages/Authentication.razor
+++ b/Timinute/Client/Pages/Authentication.razor
@@ -34,7 +34,7 @@
                 </div>
                 <p class="aurora-auth-shell__title">Sign-in failed</p>
                 <p class="aurora-auth-shell__sub">@message</p>
-                <a class="aurora-auth-shell__link" href="authentication/login">Try again</a>
+                <a class="aurora-auth-shell__link" href="/authentication/login">Try again</a>
             </div>
         </LogInFailed>
         <LogOutFailed Context="message">
@@ -51,7 +51,7 @@
                 </div>
                 <p class="aurora-auth-shell__title">Sign-out failed</p>
                 <p class="aurora-auth-shell__sub">@message</p>
-                <a class="aurora-auth-shell__link" href="">Back to home</a>
+                <a class="aurora-auth-shell__link" href="/">Back to home</a>
             </div>
         </LogOutFailed>
     </RemoteAuthenticatorView>

--- a/Timinute/Client/Pages/Authentication.razor
+++ b/Timinute/Client/Pages/Authentication.razor
@@ -4,13 +4,85 @@
 
 @if (!IsRegister)
 {
-    <RemoteAuthenticatorView Action="@Action" />
+    <RemoteAuthenticatorView Action="@Action">
+        <LoggingIn>
+            @AuthShell("Signing you in…", "Redirecting to your identity provider.")
+        </LoggingIn>
+        <CompletingLoggingIn>
+            @AuthShell("Completing sign-in…", "Verifying your session.")
+        </CompletingLoggingIn>
+        <LogOut>
+            @AuthShell("Signing you out…", "Closing your session.")
+        </LogOut>
+        <CompletingLogOut>
+            @AuthShell("Completing sign-out…", "Almost done.")
+        </CompletingLogOut>
+        <LogOutSucceeded>
+            @AuthShell("You're signed out.", "Redirecting to the home page.")
+        </LogOutSucceeded>
+        <LogInFailed Context="message">
+            <div class="aurora-auth-shell">
+                <div class="aurora-auth-shell__brand">
+                    <div class="aurora-auth-shell__mark">
+                        <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="13" r="8" />
+                            <path d="M12 9v4l2.5 2" />
+                            <path d="M9 2h6" />
+                        </svg>
+                    </div>
+                    <div class="aurora-auth-shell__wordmark">timinute<span class="aurora-auth-shell__dot">.</span></div>
+                </div>
+                <p class="aurora-auth-shell__title">Sign-in failed</p>
+                <p class="aurora-auth-shell__sub">@message</p>
+                <a class="aurora-auth-shell__link" href="authentication/login">Try again</a>
+            </div>
+        </LogInFailed>
+        <LogOutFailed Context="message">
+            <div class="aurora-auth-shell">
+                <div class="aurora-auth-shell__brand">
+                    <div class="aurora-auth-shell__mark">
+                        <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="13" r="8" />
+                            <path d="M12 9v4l2.5 2" />
+                            <path d="M9 2h6" />
+                        </svg>
+                    </div>
+                    <div class="aurora-auth-shell__wordmark">timinute<span class="aurora-auth-shell__dot">.</span></div>
+                </div>
+                <p class="aurora-auth-shell__title">Sign-out failed</p>
+                <p class="aurora-auth-shell__sub">@message</p>
+                <a class="aurora-auth-shell__link" href="">Back to home</a>
+            </div>
+        </LogOutFailed>
+    </RemoteAuthenticatorView>
 }
 
 @code {
     [Parameter] public string? Action { get; set; }
 
     private bool IsRegister => string.Equals(Action, "register", System.StringComparison.OrdinalIgnoreCase);
+
+    // Shared branded shell for the in-flight auth states — mirrors the
+    // Aurora boot splash so the sign-in / sign-out flow doesn't flash an
+    // unstyled "Completing login..." line. See Authentication.razor.css.
+    private RenderFragment AuthShell(string title, string subtitle) => __builder =>
+    {
+        <div class="aurora-auth-shell" role="status" aria-live="polite">
+            <div class="aurora-auth-shell__brand">
+                <div class="aurora-auth-shell__mark" aria-hidden="true">
+                    <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="13" r="8" />
+                        <path d="M12 9v4l2.5 2" />
+                        <path d="M9 2h6" />
+                    </svg>
+                </div>
+                <div class="aurora-auth-shell__wordmark">timinute<span class="aurora-auth-shell__dot">.</span></div>
+            </div>
+            <p class="aurora-auth-shell__title">@title</p>
+            <p class="aurora-auth-shell__sub">@subtitle</p>
+            <div class="aurora-auth-shell__progress" aria-hidden="true"></div>
+        </div>
+    };
 
     protected override void OnInitialized()
     {

--- a/Timinute/Client/Pages/Authentication.razor.css
+++ b/Timinute/Client/Pages/Authentication.razor.css
@@ -1,0 +1,108 @@
+/* Shared shell for the in-flight auth states (LoggingIn, CompletingLoggingIn,
+   LogOut, etc.). Visually mirrors the Aurora boot splash — same wordmark,
+   same progress bar — so the sign-in / sign-out flow feels continuous with
+   the app boot rather than flashing an unstyled fallback. */
+
+.aurora-auth-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    padding: 24px;
+    text-align: center;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+}
+
+.aurora-auth-shell__brand {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.aurora-auth-shell__mark {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #5B5BF5, #9D7CFF);
+    box-shadow: 0 12px 32px -10px rgba(91, 91, 245, .55);
+    display: grid;
+    place-items: center;
+    animation: aurora-auth-float 3s ease-in-out infinite;
+}
+
+.aurora-auth-shell__wordmark {
+    font-weight: 600;
+    font-size: 32px;
+    letter-spacing: -0.8px;
+    color: var(--text);
+}
+
+.aurora-auth-shell__dot {
+    color: var(--accent);
+}
+
+.aurora-auth-shell__title {
+    font: 500 18px var(--font-sans);
+    color: var(--text);
+    margin: 0;
+}
+
+.aurora-auth-shell__sub {
+    color: var(--text-mu);
+    font-size: 14px;
+    margin: 0;
+    max-width: 380px;
+}
+
+.aurora-auth-shell__progress {
+    position: relative;
+    width: 180px;
+    height: 3px;
+    background: var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+    .aurora-auth-shell__progress::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 35%;
+        background: linear-gradient(90deg, transparent, var(--accent), transparent);
+        border-radius: 999px;
+        animation: aurora-auth-bar 1.4s ease-in-out infinite;
+    }
+
+.aurora-auth-shell__link {
+    margin-top: 8px;
+    color: var(--accent);
+    text-decoration: none;
+    font: 500 14px var(--font-sans);
+}
+
+    .aurora-auth-shell__link:hover {
+        text-decoration: underline;
+    }
+
+@keyframes aurora-auth-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+}
+
+@keyframes aurora-auth-bar {
+    0% { left: -35%; }
+    100% { left: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .aurora-auth-shell__mark,
+    .aurora-auth-shell__progress::after {
+        animation: none;
+    }
+}

--- a/Timinute/Client/Pages/Profile.razor.css
+++ b/Timinute/Client/Pages/Profile.razor.css
@@ -206,21 +206,56 @@
         letter-spacing: -0.5px;
     }
 
+    /* Settings list-row treatment on mobile: each row reads as a tappable
+       list item with the label on the left and the control(s) right-aligned.
+       Matches the design intent the Aurora mobile spec deferred ("settings
+       list card on the Profile screen") while reusing the desktop card's
+       inline editors instead of building separate sheets. */
     .aurora-prefs__row {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 8px;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 16px 0;
+        min-height: 48px; /* tap-target size */
     }
 
     .aurora-prefs__label {
-        flex-basis: auto;
+        flex: 0 0 auto;
+        font-size: 14px;
+        color: var(--text);
+    }
+
+    .aurora-prefs__pills {
+        gap: 6px;
+    }
+
+    .aurora-prefs__pill {
+        padding: 6px 12px;
+        font-size: 12px;
+    }
+
+    .aurora-prefs__input {
+        width: 72px;
+        text-align: right;
     }
 
     .aurora-prefs__footer {
         justify-content: stretch;
+        margin-top: 8px;
     }
 
     .aurora-prefs__footer > * {
         flex: 1;
+    }
+}
+
+/* Tighter phones: theme pills take a full row of their own so the three
+   options remain comfortably tappable. */
+@media (max-width: 480px) {
+    .aurora-prefs__row:has(.aurora-prefs__pills) {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
     }
 }

--- a/Timinute/Client/Services/ThemeService.cs
+++ b/Timinute/Client/Services/ThemeService.cs
@@ -120,6 +120,26 @@ namespace Timinute.Client.Services
             response.EnsureSuccessStatusCode();
         }
 
+        // Convenience for callers that don't already have UserPreferencesDto
+        // in hand (e.g. the topbar quick-toggle button). Awaits the cached
+        // sync Task to recover current weeklyGoal/workdayHours, then PUTs the
+        // full DTO with the new theme. Throws on PUT failure — caller reverts
+        // via ApplyLocalAsync.
+        public async Task SetThemeOnlyAsync(ThemePreference value)
+        {
+            var prefs = await SyncFromServerAsync();
+            if (prefs == null)
+            {
+                // No prefs available (anonymous, network error). Apply locally
+                // so the UI feels responsive; the next authenticated GetMe
+                // will re-sync from server.
+                await ApplyLocalCoreAsync(value);
+                Changed?.Invoke(value);
+                return;
+            }
+            await SetAsync(value, prefs);
+        }
+
         private async Task ApplyLocalCoreAsync(ThemePreference value)
         {
             try

--- a/Timinute/Client/Shared/AuroraIcons.razor
+++ b/Timinute/Client/Shared/AuroraIcons.razor
@@ -120,5 +120,12 @@
             <polyline points="16 17 21 12 16 7" />
             <path d="M21 12H9" />
             break;
+        case "sun":
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+            break;
+        case "moon":
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            break;
     }
 </svg>

--- a/Timinute/Client/Shared/Topbar.razor
+++ b/Timinute/Client/Shared/Topbar.razor
@@ -67,10 +67,13 @@
     private string LastName = "";
     private IJSObjectReference? shortcutsModule;
 
-    // Tracks the *resolved* light/dark applied to <html data-theme>, so the
-    // toggle icon flips on System users when the OS theme changes. Initial
+    // Tracks the *resolved* light/dark applied to <html data-theme>. Initial
     // value resolved from the bootstrap script via ThemeService on first
-    // render; subsequent updates via Theme.Changed (toggle from anywhere).
+    // render; updated via Theme.Changed when toggling from Topbar or Profile,
+    // or when MainLayout's server sync brings in a different theme. Note:
+    // this state is NOT updated by the bootstrap's matchMedia listener for
+    // mid-session OS-theme changes — those re-apply data-theme on <html>
+    // but don't notify Blazor. The icon resolves correctly on next render.
     private ThemePreference currentThemeChoice = ThemePreference.System;
     private bool isDarkResolved;
     private bool isThemeBusy;
@@ -175,11 +178,23 @@
     {
         // Fired by ThemeService whenever theme changes anywhere (here, Profile,
         // server sync). Update local state without a re-PUT.
+        //
+        // Skip while ToggleTheme is in flight: it already owns the optimistic
+        // UI state, and SetThemeOnlyAsync re-fires Changed on its own success
+        // path. Without this guard the queued lambda would re-apply the same
+        // value mid-toggle, causing a redundant render.
+        if (isThemeBusy) return;
+
         InvokeAsync(async () =>
         {
-            currentThemeChoice = value;
-            isDarkResolved = await ResolveIsDarkAsync(value);
-            StateHasChanged();
+            try
+            {
+                currentThemeChoice = value;
+                isDarkResolved = await ResolveIsDarkAsync(value);
+                StateHasChanged();
+            }
+            catch (ObjectDisposedException) { /* component gone */ }
+            catch (JSDisconnectedException) { /* circuit gone */ }
         });
     }
 

--- a/Timinute/Client/Shared/Topbar.razor
+++ b/Timinute/Client/Shared/Topbar.razor
@@ -1,9 +1,11 @@
 @implements IAsyncDisposable
+@using Timinute.Shared.Dtos
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthState
 @inject Radzen.DialogService DialogService
 @inject IJSRuntime JS
 @inject Timinute.Client.Services.MobileSheetService Sheet
+@inject Timinute.Client.Services.ThemeService Theme
 
 <header class="aurora-topbar">
     <div class="aurora-topbar__left">
@@ -21,6 +23,15 @@
                 <input type="text" class="aurora-search__input" placeholder="Search tasks, projects…" />
                 <span class="aurora-search__chip">⌘K</span>
             </div>
+
+            <button type="button"
+                    class="aurora-topbar__icon-btn"
+                    @onclick="ToggleTheme"
+                    disabled="@isThemeBusy"
+                    aria-label="@(isDarkResolved ? "Switch to light theme" : "Switch to dark theme")"
+                    title="@(isDarkResolved ? "Switch to light" : "Switch to dark")">
+                <AuroraIcons Name="@(isDarkResolved ? "sun" : "moon")" Size="16" />
+            </button>
 
             <button class="aurora-quick-add" @onclick="OpenQuickAdd">
                 <AuroraIcons Name="plus" Size="16" />
@@ -56,6 +67,14 @@
     private string LastName = "";
     private IJSObjectReference? shortcutsModule;
 
+    // Tracks the *resolved* light/dark applied to <html data-theme>, so the
+    // toggle icon flips on System users when the OS theme changes. Initial
+    // value resolved from the bootstrap script via ThemeService on first
+    // render; subsequent updates via Theme.Changed (toggle from anywhere).
+    private ThemePreference currentThemeChoice = ThemePreference.System;
+    private bool isDarkResolved;
+    private bool isThemeBusy;
+
     private string Initials
     {
         get
@@ -70,6 +89,7 @@
     protected override async Task OnInitializedAsync()
     {
         Navigation.LocationChanged += OnLocationChanged;
+        Theme.Changed += OnThemeChanged;
         var auth = await AuthState.GetAuthenticationStateAsync();
         var user = auth.User;
         if (user.Identity?.IsAuthenticated == true)
@@ -91,6 +111,76 @@
             shortcutsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/topbar-shortcuts.js");
             await shortcutsModule.InvokeVoidAsync("registerCmdKFocus", ".aurora-search__input");
         }
+
+        // First render: read the bootstrap-applied theme so the icon matches
+        // what's already on screen.
+        if (firstRender)
+        {
+            currentThemeChoice = await Theme.GetCurrentAsync();
+            isDarkResolved = await ResolveIsDarkAsync(currentThemeChoice);
+            StateHasChanged();
+        }
+    }
+
+    private async Task<bool> ResolveIsDarkAsync(ThemePreference choice)
+    {
+        if (choice == ThemePreference.Dark) return true;
+        if (choice == ThemePreference.Light) return false;
+        // System: read the resolved value from the bootstrap script (which
+        // already applied data-theme to <html>). CSP-safe — no eval.
+        try
+        {
+            var resolved = await JS.InvokeAsync<string?>("__theme.getResolved");
+            return string.Equals(resolved, "dark", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task ToggleTheme()
+    {
+        if (isThemeBusy) return;
+
+        var next = isDarkResolved ? ThemePreference.Light : ThemePreference.Dark;
+        var previousChoice = currentThemeChoice;
+        var previousIsDark = isDarkResolved;
+
+        isThemeBusy = true;
+        currentThemeChoice = next;
+        isDarkResolved = next == ThemePreference.Dark;
+        StateHasChanged();
+
+        try
+        {
+            await Theme.SetThemeOnlyAsync(next);
+        }
+        catch
+        {
+            // Revert UI; ApplyLocalAsync re-applies the previous theme to
+            // <html data-theme> + localStorage without re-PUTting.
+            currentThemeChoice = previousChoice;
+            isDarkResolved = previousIsDark;
+            try { await Theme.ApplyLocalAsync(previousChoice); } catch { /* best-effort */ }
+        }
+        finally
+        {
+            isThemeBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OnThemeChanged(ThemePreference value)
+    {
+        // Fired by ThemeService whenever theme changes anywhere (here, Profile,
+        // server sync). Update local state without a re-PUT.
+        InvokeAsync(async () =>
+        {
+            currentThemeChoice = value;
+            isDarkResolved = await ResolveIsDarkAsync(value);
+            StateHasChanged();
+        });
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
@@ -144,6 +234,7 @@
     public async ValueTask DisposeAsync()
     {
         Navigation.LocationChanged -= OnLocationChanged;
+        Theme.Changed -= OnThemeChanged;
         if (shortcutsModule is not null)
         {
             try

--- a/Timinute/Client/Shared/Topbar.razor.css
+++ b/Timinute/Client/Shared/Topbar.razor.css
@@ -35,6 +35,36 @@
     flex-shrink: 0;
 }
 
+.aurora-topbar__icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    color: var(--text-mu);
+    cursor: pointer;
+    transition: background .15s ease, border-color .15s ease, color .15s ease;
+}
+
+.aurora-topbar__icon-btn:hover:not(:disabled) {
+    background: var(--accent-so);
+    border-color: var(--accent);
+    color: var(--text);
+}
+
+.aurora-topbar__icon-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.aurora-topbar__icon-btn:disabled {
+    opacity: 0.6;
+    cursor: progress;
+}
+
 .aurora-search {
     display: flex;
     align-items: center;

--- a/Timinute/Client/wwwroot/css/landing.css
+++ b/Timinute/Client/wwwroot/css/landing.css
@@ -647,7 +647,12 @@
     align-items: center;
     gap: 8px;
     background: #fff;
-    color: var(--text) !important;
+    /* Literal dark text — the .loss__card behind this button is hardcoded
+       to the always-dark #1B1A2E -> #5B5BF5 gradient regardless of theme,
+       and the button's background is hardcoded white, so the text must
+       also be hardcoded dark. var(--text) flips to a light color in dark
+       mode and produced light-on-white (illegible). */
+    color: #1A1A24 !important;
     text-decoration: none;
     font-size: 14.5px;
     font-weight: 500;

--- a/Timinute/Client/wwwroot/index.html
+++ b/Timinute/Client/wwwroot/index.html
@@ -123,6 +123,38 @@
                 animation: none;
             }
         }
+
+        /* Dark-mode boot splash. theme-bootstrap.js sets data-theme on <html>
+           synchronously above (loaded in <head> before this <style> block),
+           so these overrides apply on first paint without flashing the
+           light splash. Hex values match aurora.css [data-theme="dark"]. */
+        html[data-theme="dark"], html[data-theme="dark"] body {
+            background: #0F0E1A;
+        }
+
+        html[data-theme="dark"] .aurora-boot {
+            color: #EFEDF8;
+        }
+
+        html[data-theme="dark"] .aurora-boot__wordmark {
+            color: #EFEDF8;
+        }
+
+        html[data-theme="dark"] .aurora-boot__wordmark-dot {
+            color: #7C7CFF;
+        }
+
+        html[data-theme="dark"] .aurora-boot__sub {
+            color: #9C99B0;
+        }
+
+        html[data-theme="dark"] .aurora-boot__progress {
+            background: #262438;
+        }
+
+        html[data-theme="dark"] .aurora-boot__progress::after {
+            background: linear-gradient(90deg, transparent, #7C7CFF, transparent);
+        }
     </style>
 </head>
 

--- a/Timinute/Client/wwwroot/js/theme-bootstrap.js
+++ b/Timinute/Client/wwwroot/js/theme-bootstrap.js
@@ -50,5 +50,11 @@
         get: function () {
             try { return localStorage.getItem(KEY) || 'System'; } catch { return 'System'; }
         },
+        // Returns "dark" or "light" — the resolved value currently on
+        // <html data-theme>. Used by the topbar toggle to render the
+        // correct icon when the stored value is "System".
+        getResolved: function () {
+            return root.getAttribute('data-theme') || 'light';
+        },
     };
 })();

--- a/Timinute/Server/Pages/Shared/_Layout.cshtml
+++ b/Timinute/Server/Pages/Shared/_Layout.cshtml
@@ -9,6 +9,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] — Timinute</title>
 
+    <!-- Pre-page theme bootstrap — must run before first paint so the
+         user's stored theme is applied without a flash of light-mode.
+         Same script the Blazor client uses; served from the Client's
+         wwwroot which is exposed at the app root. See
+         Client/wwwroot/js/theme-bootstrap.js. -->
+    <script src="~/js/theme-bootstrap.js"></script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@@400;500;600;700&display=swap" rel="stylesheet" />

--- a/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
+++ b/Timinute/Server/wwwroot/Identity/css/aurora-identity.css
@@ -21,6 +21,26 @@
     --danger: #EF4444;
 }
 
+/* Dark-mode tokens — mirror aurora.css [data-theme="dark"] so the
+   Identity Razor pages (Login, Register, Manage subpages) render
+   correctly when the user has chosen Dark or System+OS-dark. The
+   theme-bootstrap.js loaded in _Layout.cshtml sets data-theme on
+   <html> synchronously before first paint, so the overrides apply
+   without a flash. */
+html[data-theme="dark"] {
+    --bg: #0F0E1A;
+    --surface: #171627;
+    --surface-2: #1E1D31;
+    --text: #EFEDF8;
+    --text-mu: #9C99B0;
+    --text-dim: #7A7894;
+    --border: #262438;
+    --accent: #7C7CFF;
+    --accent-so: #1F1E3D;
+    --accent-ink: #B5B5FF;
+    --danger: #F87171;
+}
+
 html, body {
     margin: 0;
     padding: 0;

--- a/Timinute/Shared/Dtos/ThemePreference.cs
+++ b/Timinute/Shared/Dtos/ThemePreference.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Timinute.Shared.Dtos
 {
     // Lives in Shared so both server (UserPreferences entity) and client
@@ -7,6 +9,14 @@ namespace Timinute.Shared.Dtos
     // configured in ApplicationDbContext. Without this alignment EF can't
     // distinguish "user set Theme = Light" from "Theme is unset" because
     // both look like the CLR default of the enum.
+    //
+    // [JsonConverter] attached to the type so both server and client
+    // serialize/deserialize as strings ("Light"/"Dark"/"System") without
+    // each project needing its own JsonStringEnumConverter registration.
+    // Without this the server emitted string but the client (no global
+    // converter) tried to deserialize as int -> JsonException -> Profile
+    // page silently fell back to "Could not load profile.".
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum ThemePreference
     {
         System,


### PR DESCRIPTION
## Summary

Three small additions extending the v2.1 Settings cluster (PR #40, already merged to develop) — none of them by themselves justifies a feature, together they "complete the loop" so v2.1 ships with the obvious follow-throughs already done.

## Changes

| # | Area | Change |
|---|------|--------|
| 1 | Topbar | Sun/moon icon button on desktop right cluster. Click toggles **Light ↔ Dark**. Icon flips based on the *resolved* `<html data-theme>`, so System users see the correct icon for their OS preference. New `ThemeService.SetThemeOnlyAsync` helper + `__theme.getResolved` JS export (CSP-safe, no `eval`). |
| 2 | Profile (mobile) | CSS-only restyle of the existing Preferences card on screens ≤768px to read as a settings list — horizontal rows, label left, control right-aligned, 48px tap targets. Tighter phones (≤480px) keep the theme pills on a full-width row. Folds in the deferred Aurora-mobile spec intent ("settings list card on Profile") without a new component. |
| 3 | Dashboard | "Today X.Xh / Yh target" indicator on the hero card's chip row. `WorkdayHoursPerDay` (added in v2.1 as forward-looking storage) now drives a real UI element. Fallback 8.0h on GetMe failure. |

## Verification

- `dotnet build Timinute.sln` — 0 errors.
- `dotnet test` — 101/101 passing (no new tests; all changes are client-side UI/CSS).
- Theme toggle: optimistic UI + revert via `ApplyLocalAsync` on PUT failure (no double-PUT, same pattern as Profile's pills after the v2.1 I2 fix).
- `ThemeService.Changed` event keeps the topbar icon in sync if the user toggles via Profile too.

## Test plan

- [ ] CI Build & Test green on this branch.
- [ ] Topbar shows moon icon on light theme; click → instant dark mode + a `PUT /User/me/preferences` in network panel; icon flips to sun.
- [ ] System mode + OS-theme change → topbar icon flips without a PUT (just the `Changed` event re-resolves).
- [ ] Mobile (≤768px): Preferences card renders as horizontal list rows with right-aligned values.
- [ ] Tighter mobile (≤480px): theme pills wrap to their own row above goal/workday rows.
- [ ] Dashboard hero card shows "Today X.Xh / Yh target" reflecting saved `WorkdayHoursPerDay`.
- [ ] Track a session today → reload Dashboard → today's hours number updates.

## Out of scope (still deferred)

Notifications topbar bell, email-on-summary, Quick-add keyboard shortcut, integration tests for the `[ApiController]` 422 path (raised in PR #40 review #6/#7).