### PR TITLE
feat(docker): docker distribution + compose bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/bin
+**/obj
+**/.vs
+**/.git
+**/node_modules
+docs
+screenshots
+Server.Tests
+*.md
+.github
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env and edit. .env is gitignored.
+
+# Bundled SQL Server SA password. SQL Server requires 8+ chars,
+# mix of upper/lower/digit/symbol.
+MSSQL_SA_PASSWORD=ChangeMe.Strong-Password-123!
+
+# Public URL Timinute is reachable on. MUST be https in production
+# and MUST exactly match the URL your reverse proxy serves (no trailing slash).
+IdentityServer__Authority=https://timinute.example.com
+
+# Host port. Container always listens on 8080 internally.
+TIMINUTE_PORT=8080
+
+# Image tag: `latest` (release), `develop` (preview), or a pinned version like `2.1.0`.
+TIMINUTE_TAG=latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Publish
+
+on:
+  push:
+    tags: ['v*']
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jame581/timinute
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/develop' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,6 @@ CLAUDE.md
 
 # Claude Code superpowers runtime state
 .superpowers/
+
+# Docker self-host runtime config (copy of .env.example)
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /src
+
+# csproj-only first → restore layer caches well
+COPY Timinute.sln ./
+COPY Timinute/Server/Timinute.Server.csproj  Timinute/Server/
+COPY Timinute/Client/Timinute.Client.csproj  Timinute/Client/
+COPY Timinute/Shared/Timinute.Shared.csproj  Timinute/Shared/
+RUN dotnet restore Timinute/Server/Timinute.Server.csproj -a $TARGETARCH
+
+COPY . .
+RUN dotnet publish Timinute/Server/Timinute.Server.csproj \
+        -c Release -a $TARGETARCH --no-restore -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+USER app
+COPY --from=build --chown=app:app /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080 \
+    DatabaseMigrationOnStartup=true
+EXPOSE 8080
+VOLUME ["/keys"]
+ENTRYPOINT ["dotnet", "Timinute.Server.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ RUN mkdir -p /keys && chown app:app /keys
 USER app
 COPY --from=build --chown=app:app /app/publish .
 ENV ASPNETCORE_URLS=http://+:8080 \
-    DatabaseMigrationOnStartup=true
+    DatabaseMigrationOnStartup=true \
+    DataProtection__KeyPath=/keys/data-protection \
+    IdentityServer__KeyManagement__KeyPath=/keys \
+    ForwardedHeaders__AllowAnyProxy=true
 EXPOSE 8080
 # VOLUME is metadata; the actual /keys directory was created and chowned
 # earlier (as root) before the USER switch.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN dotnet publish Timinute/Server/Timinute.Server.csproj \
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
+RUN mkdir -p /keys && chown app:app /keys
 USER app
 COPY --from=build --chown=app:app /app/publish .
 ENV ASPNETCORE_URLS=http://+:8080 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,7 @@ COPY --from=build --chown=app:app /app/publish .
 ENV ASPNETCORE_URLS=http://+:8080 \
     DatabaseMigrationOnStartup=true
 EXPOSE 8080
+# VOLUME is metadata; the actual /keys directory was created and chowned
+# earlier (as root) before the USER switch.
 VOLUME ["/keys"]
 ENTRYPOINT ["dotnet", "Timinute.Server.dll"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Latest release](https://img.shields.io/github/v/release/jame581/Timinute)](https://github.com/jame581/Timinute/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
+[![Docker](https://img.shields.io/badge/ghcr.io-jame581%2Ftiminute-blue?logo=docker)](https://github.com/jame581/Timinute/pkgs/container/timinute)
 
 The free, open-source time tracker that respects your minutes. Track work hours across projects, see exactly where your time goes, and get clear weekly overviews — all in a self-hostable Blazor WebAssembly app.
 
@@ -83,6 +84,18 @@ Seeded test users (passwords are intentionally trivial — local dev only):
 | test1@email.com | Basic |
 | test2@email.com | Basic |
 | test3@email.com | Basic |
+
+## Run with Docker
+
+```bash
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
+cp .env.example .env
+# edit .env: set MSSQL_SA_PASSWORD and IdentityServer__Authority
+docker compose up -d
+```
+
+The app comes up on `http://localhost:8080`. For real deployments, put a TLS-terminating reverse proxy in front and set `IdentityServer__Authority` to the public https URL. Full self-host guide (reverse proxy, external SQL, backups, upgrades): [`docs/DOCKER.md`](docs/DOCKER.md).
 
 ## Production deployment
 

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -246,11 +246,15 @@ void IdentitySetup()
     }
     else
     {
+        var keyPath = builder.Configuration["IdentityServer:KeyManagement:KeyPath"] ?? "/keys";
+
         // Duende IdentityServer enables automatic key management by default.
-        // Keys are generated, rotated, and persisted to the /keys directory.
+        // Keys are generated, rotated, and persisted to KeyPath. This MUST be a
+        // persistent volume in containerised / multi-replica deployments.
         identityServerBuilder.Services.Configure<Duende.IdentityServer.Configuration.KeyManagementOptions>(options =>
         {
             options.Enabled = true;
+            options.KeyPath = keyPath;
         });
     }
 }

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,5 +1,6 @@
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -101,6 +102,17 @@ builder.Services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
 // Swagger Configuration
 SwaggerSetup();
 
+// Reverse-proxy support. Docker users terminate TLS upstream; we trust
+// X-Forwarded-* from any source inside the private container network.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                             | ForwardedHeaders.XForwardedProto
+                             | ForwardedHeaders.XForwardedHost;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -125,6 +137,7 @@ else
     app.UseHsts();
 }
 
+app.UseForwardedHeaders();
 app.UseHttpsRedirection();
 
 app.UseResponseCaching();

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -115,6 +115,13 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 
 var app = builder.Build();
 
+if (app.Configuration.GetValue("DatabaseMigrationOnStartup", true))
+{
+    using var scope = app.Services.CreateScope();
+    scope.ServiceProvider.GetRequiredService<ApplicationDbContext>()
+         .Database.Migrate();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -26,9 +26,9 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-if (!builder.Environment.IsDevelopment())
+var dpKeysPath = builder.Configuration["DataProtection:KeyPath"];
+if (!string.IsNullOrEmpty(dpKeysPath))
 {
-    var dpKeysPath = builder.Configuration["DataProtection:KeyPath"] ?? "/keys/data-protection";
     builder.Services.AddDataProtection()
         .PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath));
 }
@@ -118,8 +118,16 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
                              | ForwardedHeaders.XForwardedProto
                              | ForwardedHeaders.XForwardedHost;
-    options.KnownIPNetworks.Clear();
-    options.KnownProxies.Clear();
+
+    // Only clear the known-proxy trust list when the operator explicitly opts in.
+    // The default ASP.NET Core behavior (loopback-only trust) is safer for
+    // accidentally-internet-exposed deployments; Docker sets this true in its
+    // ENV because the container talks to a proxy on a private docker network.
+    if (builder.Configuration.GetValue("ForwardedHeaders:AllowAnyProxy", false))
+    {
+        options.KnownIPNetworks.Clear();
+        options.KnownProxies.Clear();
+    }
 });
 
 // Same-origin auth → SameSite=Lax is correct and works in both HTTP-only
@@ -136,12 +144,14 @@ builder.Services.Configure<CookiePolicyOptions>(options =>
 
 var app = builder.Build();
 
-if (app.Configuration.GetValue("DatabaseMigrationOnStartup", true))
+if (app.Configuration.GetValue("DatabaseMigrationOnStartup", false))
 {
     using var scope = app.Services.CreateScope();
     scope.ServiceProvider.GetRequiredService<ApplicationDbContext>()
          .Database.Migrate();
 }
+
+app.UseForwardedHeaders();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -164,8 +174,6 @@ else
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
-
-app.UseForwardedHeaders();
 app.UseCookiePolicy();
 app.UseHttpsRedirection();
 
@@ -268,11 +276,11 @@ void IdentitySetup()
     }
     else
     {
-        var keyPath = builder.Configuration["IdentityServer:KeyManagement:KeyPath"] ?? "/keys";
+        var keyPath = builder.Configuration["IdentityServer:KeyManagement:KeyPath"];
 
         // Duende IdentityServer enables automatic key management by default.
-        // Keys are generated, rotated, and persisted to KeyPath. This MUST be a
-        // persistent volume in containerised / multi-replica deployments.
+        // KeyPath defaults to "keys" relative to CWD; set explicitly via config
+        // for any deployment with a stable persistent directory.
         // NOTE: We configure IdentityServerOptions (not KeyManagementOptions) because
         // Duende registers an IPostConfigureOptions<KeyManagementOptions> that copies
         // values from IdentityServerOptions.KeyManagement.* and would otherwise
@@ -280,7 +288,10 @@ void IdentitySetup()
         identityServerBuilder.Services.Configure<Duende.IdentityServer.Configuration.IdentityServerOptions>(options =>
         {
             options.KeyManagement.Enabled = true;
-            options.KeyManagement.KeyPath = keyPath;
+            if (!string.IsNullOrEmpty(keyPath))
+            {
+                options.KeyManagement.KeyPath = keyPath;
+            }
         });
     }
 }

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -1,5 +1,7 @@
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.CookiePolicy;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -23,6 +25,13 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+if (!builder.Environment.IsDevelopment())
+{
+    var dpKeysPath = builder.Configuration["DataProtection:KeyPath"] ?? "/keys/data-protection";
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath));
+}
 
 // Identity configuration
 IdentitySetup();
@@ -113,6 +122,18 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownProxies.Clear();
 });
 
+// Same-origin auth → SameSite=Lax is correct and works in both HTTP-only
+// (local smoke / dev) and HTTPS-behind-reverse-proxy (production). The
+// default SameSite=None setting on Identity / IdentityServer cookies is
+// dropped silently by browsers when the request is not HTTPS, which breaks
+// the login flow in any non-TLS deployment. Secure flag mirrors the request
+// scheme so it's set in production-https and unset in http-smoke.
+builder.Services.Configure<CookiePolicyOptions>(options =>
+{
+    options.MinimumSameSitePolicy = SameSiteMode.Lax;
+    options.Secure = CookieSecurePolicy.SameAsRequest;
+});
+
 var app = builder.Build();
 
 if (app.Configuration.GetValue("DatabaseMigrationOnStartup", true))
@@ -145,6 +166,7 @@ else
 }
 
 app.UseForwardedHeaders();
+app.UseCookiePolicy();
 app.UseHttpsRedirection();
 
 app.UseResponseCaching();

--- a/Timinute/Server/Program.cs
+++ b/Timinute/Server/Program.cs
@@ -251,10 +251,14 @@ void IdentitySetup()
         // Duende IdentityServer enables automatic key management by default.
         // Keys are generated, rotated, and persisted to KeyPath. This MUST be a
         // persistent volume in containerised / multi-replica deployments.
-        identityServerBuilder.Services.Configure<Duende.IdentityServer.Configuration.KeyManagementOptions>(options =>
+        // NOTE: We configure IdentityServerOptions (not KeyManagementOptions) because
+        // Duende registers an IPostConfigureOptions<KeyManagementOptions> that copies
+        // values from IdentityServerOptions.KeyManagement.* and would otherwise
+        // overwrite anything we set directly on KeyManagementOptions.
+        identityServerBuilder.Services.Configure<Duende.IdentityServer.Configuration.IdentityServerOptions>(options =>
         {
-            options.Enabled = true;
-            options.KeyPath = keyPath;
+            options.KeyManagement.Enabled = true;
+            options.KeyManagement.KeyPath = keyPath;
         });
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       MSSQL_PID: Express
     volumes:
       - timinute-data:/var/opt/mssql
+    # Probes sqlcmd in the SQL Server 2025 image. If a future CU relocates
+    # mssql-tools (e.g. to mssql-tools19), swap to a TCP probe:
+    # test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/1433' || exit 1"]
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -No -Q 'SELECT 1' || exit 1"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+name: timinute
+
+services:
+  app:
+    image: ghcr.io/jame581/timinute:${TIMINUTE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: >-
+        Server=db,1433;Database=Timinute;User Id=sa;
+        Password=${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env};
+        TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=true
+      IdentityServer__Authority: ${IdentityServer__Authority:?set IdentityServer__Authority in .env}
+    ports:
+      - "${TIMINUTE_PORT:-8080}:8080"
+    volumes:
+      - timinute-keys:/keys
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env}
+      MSSQL_PID: Express
+    volumes:
+      - timinute-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -No -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+volumes:
+  timinute-keys:
+  timinute-data:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -82,7 +82,7 @@ docker compose exec db bash -c \
    -Q 'BACKUP DATABASE Timinute TO DISK = N\"/var/opt/mssql/data/Timinute.bak\" WITH FORMAT, INIT'"
 
 docker cp "$(docker compose ps -q db):/var/opt/mssql/data/Timinute.bak" \
-  "./Timinute-$(Get-Date -Format yyyyMMdd).bak"
+  "./Timinute-$(date +%Y%m%d).bak"
 
 # Snapshot signing and data-protection keys
 docker run --rm \
@@ -90,6 +90,8 @@ docker run --rm \
   -v "$(pwd)":/out \
   alpine tar -czf "/out/timinute-keys-$(date +%Y%m%d).tar.gz" -C /keys .
 ```
+
+PowerShell users: replace `$(date +%Y%m%d)` with `$(Get-Date -Format yyyyMMdd)` in the snippets above.
 
 To restore the keys volume from a backup:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,283 @@
+# Running Timinute with Docker
+
+Timinute publishes a multi-arch Docker image (`linux/amd64` + `linux/arm64`) to GitHub Container Registry. The bundled `docker-compose.yml` starts the app alongside a SQL Server container for a five-minute self-host experience. For production you typically replace the bundled SQL with your own and run Timinute behind a reverse proxy that handles TLS.
+
+## Quick start
+
+```bash
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
+cp .env.example .env
+# edit .env: set MSSQL_SA_PASSWORD and IdentityServer__Authority
+docker compose up -d
+```
+
+The app comes up on `http://localhost:8080` (configurable via `TIMINUTE_PORT`). For production, put a reverse proxy in front with a real TLS certificate and set `IdentityServer__Authority` to the public https URL (e.g. `https://timinute.example.com`).
+
+## Image tags
+
+| Tag                 | Channel        | When it advances                          |
+|---------------------|----------------|-------------------------------------------|
+| `latest`            | Stable release | On every `v*` git tag                     |
+| `2.1.0`, `2.1`, `2` | Pinned release | On the corresponding `v*` git tag         |
+| `develop`           | Preview        | On every push to the `develop` branch     |
+| `@sha256:...`       | Digest pin     | Never moves — recommended for production  |
+
+Pin by digest in production to get deterministic, immutable deployments:
+
+```yaml
+image: ghcr.io/jame581/timinute@sha256:abc123...
+```
+
+## Configuration reference
+
+All settings flow through ASP.NET Core's hierarchical configuration — environment variables with `__` between segments override `appsettings.json`. The most-frequently-overridden ones:
+
+| Variable                                     | Default (in container)    | Purpose                                                   |
+|----------------------------------------------|---------------------------|-----------------------------------------------------------|
+| `ConnectionStrings__DefaultConnection`       | _(set in compose)_        | SQL Server connection string                              |
+| `IdentityServer__Authority`                  | `https://localhost:7047`  | OIDC issuer URL — must exactly match the browser URL      |
+| `IdentityServer__KeyManagement__KeyPath`     | `/keys`                   | Directory for Duende signing keys (rarely changed)        |
+| `DataProtection__KeyPath`                    | `/keys/data-protection`   | Directory for ASP.NET data protection keys (rarely changed) |
+| `DatabaseMigrationOnStartup`                 | `true`                    | Auto-apply EF migrations on container start               |
+| `ASPNETCORE_ENVIRONMENT`                     | `Production` (in compose) | Standard ASP.NET environment flag                         |
+| `ASPNETCORE_URLS`                            | `http://+:8080`           | Listen address inside the container                       |
+| `TrashRetention__Days`                       | `30`                      | Soft-delete retention days before hard-purge              |
+| `TrashRetention__PurgeIntervalHours`         | `24`                      | How often the background purge service runs               |
+
+### `IdentityServer__Authority` — the most important setting
+
+This value must **exactly** match the URL the user's browser uses to reach the app — scheme, host, port (if non-standard), no trailing slash. Duende IdentityServer embeds this URL into every JWT it issues, and the app validates it on each request.
+
+| Scenario                              | Correct value                         |
+|---------------------------------------|---------------------------------------|
+| Behind a reverse proxy with TLS       | `https://timinute.example.com`        |
+| Local smoke test, no proxy            | `http://localhost:8080`               |
+| Custom port, no TLS                   | `http://localhost:9000`               |
+
+A mismatch between `IdentityServer__Authority` and the actual browser URL produces `Invalid redirect_uri` errors from Duende and prevents any user from logging in. See [Troubleshooting](#troubleshooting) for the full diagnostic.
+
+## Volumes
+
+| Volume          | Mount path inside container | Holds                                                       |
+|-----------------|-----------------------------|------------------------------------------------------------|
+| `timinute-data` | `/var/opt/mssql`            | SQL Server data and logs (bundled DB only)                  |
+| `timinute-keys` | `/keys`                     | IdentityServer signing keys AND ASP.NET data protection keys |
+
+The `timinute-keys` volume holds two subdirectories:
+
+- `/keys` — Duende IdentityServer JWT signing keys
+- `/keys/data-protection` — ASP.NET Core data protection keys, which encrypt cookies, antiforgery tokens, and Duende's persisted signing keys at rest
+
+**Both subdirectories live in the same named volume.** Losing `timinute-keys` triggers two simultaneous failures: every user is immediately logged out (signing keys rotated), and the app throws `CryptographicException: The key {guid} was not found in the key ring` on the next request (the data protection keys that encrypted the old signing keys are also gone). Always back up this volume before any destructive operation.
+
+Losing `timinute-data` means losing all user data.
+
+### Backing up
+
+```bash
+# Snapshot SQL data via sqlcmd inside the db container
+docker compose exec db bash -c \
+  "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"\$MSSQL_SA_PASSWORD\" -No \
+   -Q 'BACKUP DATABASE Timinute TO DISK = N\"/var/opt/mssql/data/Timinute.bak\" WITH FORMAT, INIT'"
+
+docker cp "$(docker compose ps -q db):/var/opt/mssql/data/Timinute.bak" \
+  "./Timinute-$(Get-Date -Format yyyyMMdd).bak"
+
+# Snapshot signing and data-protection keys
+docker run --rm \
+  -v timinute-keys:/keys \
+  -v "$(pwd)":/out \
+  alpine tar -czf "/out/timinute-keys-$(date +%Y%m%d).tar.gz" -C /keys .
+```
+
+To restore the keys volume from a backup:
+
+```bash
+docker run --rm \
+  -v timinute-keys:/keys \
+  -v "$(pwd)":/backup \
+  alpine tar -xzf /backup/timinute-keys-20260515.tar.gz -C /keys
+```
+
+## Reverse proxy
+
+The container speaks plain HTTP on port 8080. For any deployment where users connect over the internet, put a TLS-terminating reverse proxy in front. The app's `ForwardedHeaders` middleware is configured to trust `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` from any upstream inside the Docker network, so the correct scheme reaches IdentityServer.
+
+Three examples:
+
+### Caddy (most ergonomic)
+
+Caddy auto-provisions a Let's Encrypt certificate and forwards the necessary headers out of the box.
+
+```caddyfile
+timinute.example.com {
+    reverse_proxy timinute-app:8080
+}
+```
+
+Add Caddy as a third service in compose or run it as a separate stack on a shared external Docker network.
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name timinute.example.com;
+    ssl_certificate     /etc/letsencrypt/live/timinute.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/timinute.example.com/privkey.pem;
+
+    location / {
+        proxy_pass         http://timinute-app:8080;
+        proxy_set_header   Host               $host;
+        proxy_set_header   X-Real-IP          $remote_addr;
+        proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto  $scheme;
+        proxy_set_header   X-Forwarded-Host   $host;
+    }
+}
+```
+
+The `X-Forwarded-Proto $scheme;` line is required. Without it the app sees an `http://` issuer even when users connect over HTTPS, causing OIDC validation to fail.
+
+### Traefik
+
+Add these labels to the `app` service in `docker-compose.yml`:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.timinute.rule=Host(`timinute.example.com`)"
+  - "traefik.http.routers.timinute.entrypoints=websecure"
+  - "traefik.http.routers.timinute.tls.certresolver=letsencrypt"
+  - "traefik.http.services.timinute.loadbalancer.server.port=8080"
+```
+
+Traefik sets forwarded headers automatically when using its standard HTTPS entrypoint.
+
+## External SQL Server
+
+To use an existing SQL Server instead of the bundled one:
+
+1. Comment out the entire `db` service block in `docker-compose.yml`.
+2. Remove the `depends_on` block from the `app` service (it references `db`).
+3. In `.env`, set a full connection string and pass it through compose. The simplest approach is to replace the inline `ConnectionStrings__DefaultConnection` value in compose:
+
+   ```yaml
+   ConnectionStrings__DefaultConnection: ${ConnectionStrings__DefaultConnection}
+   ```
+
+   Then add to `.env`:
+
+   ```bash
+   ConnectionStrings__DefaultConnection=Server=your-sql-host,1433;Database=Timinute;User Id=sa;Password=...;TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=true
+   ```
+
+4. `MSSQL_SA_PASSWORD` is no longer used; remove it from `.env`.
+5. Ensure the target database exists before first start. `DatabaseMigrationOnStartup=true` will create tables but not the database itself.
+
+## Upgrading
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Schema migrations apply automatically on container start (`DatabaseMigrationOnStartup=true`). Schema changes are forward-only: once a newer image migrates the database, you cannot downgrade to an older image. Back up `timinute-data` before upgrading.
+
+## Disabling auto-migrate
+
+For multi-replica deployments or DBA-managed schemas, disable the automatic migration on the app replicas and run a separate one-shot migration container before rolling new app containers:
+
+```bash
+# Step 1: apply migrations with a short-lived container
+docker run --rm \
+    -e ConnectionStrings__DefaultConnection="Server=your-sql-host,1433;Database=Timinute;..." \
+    -e DatabaseMigrationOnStartup=true \
+    ghcr.io/jame581/timinute:2.2.0
+# exits 0 once migrations are done
+
+# Step 2: start (or roll) app replicas with migration disabled
+docker compose up -d
+# docker-compose.yml should include: DatabaseMigrationOnStartup=false
+```
+
+This prevents concurrent migration attempts when multiple containers start simultaneously.
+
+## Cookie and session behavior
+
+The app uses SameSite=Lax cookies with `Secure` set to match the request scheme (`SameAsRequest`). This means:
+
+- Behind a TLS-terminating reverse proxy (production): cookies are `Secure`, HTTPS-only.
+- HTTP-only smoke test or local dev: cookies work without `Secure`, which browsers allow for `localhost`.
+
+This policy is transparent to most users. It is documented here for operators who need to audit cookie behavior or who are customizing the authentication stack.
+
+## Troubleshooting
+
+**"Invalid redirect_uri: http://..." / OIDC login never completes**
+
+The `IdentityServer__Authority` value does not match the URL the browser is using. Check three things:
+
+1. `IdentityServer__Authority` in `.env` matches the exact scheme+host the browser hits (e.g. `https://timinute.example.com`, not `http://`).
+2. No trailing slash on the value.
+3. If behind a reverse proxy, confirm the proxy is running and routing correctly before diagnosing the app.
+
+For a local no-TLS smoke test, the correct value is `http://localhost:8080`, not `https://`.
+
+**Login form submits and "User logged in" appears in logs, but the app redirects back unauthenticated**
+
+This is a cookie SameSite/Secure policy mismatch. Symptoms: the login page accepts credentials and the server log shows `User logged in`, but the browser ends up back on the login page on every redirect. Diagnostic steps:
+
+1. Open browser dev tools, go to Application > Cookies. After login, check whether a `.AspNetCore.Cookies` (or similar) cookie is present.
+2. If a cookie with `Secure` flag is being set but the request is over plain HTTP, the browser silently drops it.
+3. The current image uses `SameAsRequest` so Secure follows the scheme — this should not occur with the shipped configuration. If you have customized the cookie policy, revert to the defaults and verify.
+
+**"Invalid issuer" / JWT validation fails after login**
+
+The OIDC client (Blazor WASM) validates the `iss` claim in the JWT against the configured authority. If `IdentityServer__Authority` changed between container restarts, old tokens will fail validation until they expire. Force re-login by clearing browser cookies for the site.
+
+**All users are logged out after `docker compose down && docker compose up`**
+
+The `timinute-keys` volume was not persisted. IdentityServer regenerated its signing keys on restart, invalidating every previously issued token. Confirm the volume exists and is mounted:
+
+```bash
+docker volume ls | grep timinute-keys
+docker inspect timinute_timinute-keys
+```
+
+If the volume was deleted (e.g. via `docker compose down -v`), it cannot be recovered without a backup. All users must log in again. This is expected behavior for a clean teardown — use `docker compose down` (without `-v`) for routine restarts.
+
+**SQL container stuck in `starting` or `unhealthy` (~30–60s on first boot)**
+
+Normal. SQL Server initializes `master`, `tempdb`, and system databases on first start. The healthcheck has a `start_period: 30s` for this. If the container stays `unhealthy` past 5 minutes, check:
+
+```bash
+docker compose logs db
+```
+
+Common causes: `MSSQL_SA_PASSWORD` does not satisfy SQL Server's complexity rules (8+ characters, mixed case, at least one digit, at least one symbol); or the `timinute-data` volume was initialized with a different password (recreate with `docker compose down -v`, noting this destroys all data).
+
+**App starts but immediately exits — "Cannot open database" or migration failure**
+
+The `app` container uses `depends_on: db: condition: service_healthy`, so it will not start until the SQL healthcheck passes. If you see this immediately after `docker compose up -d`, check whether the `db` service ever became healthy:
+
+```bash
+docker compose ps
+docker compose logs db --tail=50
+```
+
+**`X-Forwarded-Proto` not honored — the app sees `http://` even behind an HTTPS proxy**
+
+Confirm your reverse proxy is setting the header. nginx requires the explicit `proxy_set_header X-Forwarded-Proto $scheme;` line — it is not inherited from any default. Caddy and Traefik set it automatically. You can verify by adding `app.Use(async (ctx, next) => { Console.WriteLine(ctx.Request.Scheme); await next(); });` temporarily to `Program.cs`, or by checking Duende logs for the issuer it computed.
+
+**"CryptographicException: The key {guid} was not found in the key ring"**
+
+This means the data protection keys that were used to encrypt Duende's persisted signing keys are missing. It happens when the `timinute-keys` volume is recreated while Duende still has references to signing keys it encrypted with the old data protection keys. The fix is to restore both from backup, or to accept that existing sessions are invalid and bring up a fresh stack:
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+All users will need to log in again after this.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -39,7 +39,8 @@ All settings flow through ASP.NET Core's hierarchical configuration — environm
 | `IdentityServer__Authority`                  | `https://localhost:7047`  | OIDC issuer URL — must exactly match the browser URL      |
 | `IdentityServer__KeyManagement__KeyPath`     | `/keys`                   | Directory for Duende signing keys (rarely changed)        |
 | `DataProtection__KeyPath`                    | `/keys/data-protection`   | Directory for ASP.NET data protection keys (rarely changed) |
-| `DatabaseMigrationOnStartup`                 | `true`                    | Auto-apply EF migrations on container start               |
+| `DatabaseMigrationOnStartup`                 | `false` in code; `true` in Docker image | Auto-apply EF migrations on start. Non-Docker production deployments must opt in explicitly or run migrations manually. |
+| `ForwardedHeaders__AllowAnyProxy`            | `false` in code; `true` in Docker image | Clears ASP.NET Core's loopback-only proxy trust list. The Docker image sets this because the container talks to a reverse proxy over a private network. Leave unset if the app is directly internet-exposed without a proxy. |
 | `ASPNETCORE_ENVIRONMENT`                     | `Production` (in compose) | Standard ASP.NET environment flag                         |
 | `ASPNETCORE_URLS`                            | `http://+:8080`           | Listen address inside the container                       |
 | `TrashRetention__Days`                       | `30`                      | Soft-delete retention days before hard-purge              |
@@ -176,7 +177,7 @@ To use an existing SQL Server instead of the bundled one:
    ```
 
 4. `MSSQL_SA_PASSWORD` is no longer used; remove it from `.env`.
-5. Ensure the target database exists before first start. `DatabaseMigrationOnStartup=true` will create tables but not the database itself.
+5. With `DatabaseMigrationOnStartup=true` (the Docker default), EF Core will create the database if it doesn't already exist, *provided* the SQL login has `CREATE DATABASE` permission. Restricted logins should pre-create the database (empty) and grant the login `db_owner` on it.
 
 ## Upgrading
 

--- a/docs/superpowers/plans/2026-05-15-docker-distribution.md
+++ b/docs/superpowers/plans/2026-05-15-docker-distribution.md
@@ -1,0 +1,930 @@
+# Docker Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Docker image + bundled `docker-compose.yml` as a second distribution channel for Timinute, published to GHCR as `ghcr.io/jame581/timinute` for `linux/amd64` + `linux/arm64`, while leaving the existing per-OS release tarballs untouched.
+
+**Architecture:** Multi-stage `Dockerfile` on `mcr.microsoft.com/dotnet/aspnet:10.0` (Debian). Bundled compose pairs the app with `mcr.microsoft.com/mssql/server:2025-latest` and named volumes for `/keys` (IdentityServer signing keys) and the SQL data dir. Two small Program.cs edits — explicit `ForwardedHeaders` middleware (for reverse-proxy compatibility) and a config-gated `Database.Migrate()` at startup — round out the runtime. Publishing happens via a new `docker-publish.yml` workflow triggered on `v*` tags (release channel) and `develop` pushes (preview channel).
+
+**Tech Stack:** Docker, docker compose v2, GitHub Actions, `docker/build-push-action`, `docker/metadata-action`, ASP.NET Core 10, EF Core 10.
+
+**Source spec:** `docs/superpowers/specs/2026-05-15-docker-distribution-design.md` (commit `1dff0d7`).
+
+**Working branch:** All tasks run on a new feature branch `feature/docker-distribution`, PR'd into `develop`. Merging to `develop` publishes the `:develop` image automatically. A later `v*` tag from `master` publishes `:latest`/`:X.Y.Z`/`:X.Y`/`:X`.
+
+---
+
+## Task 0: Create the feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Confirm clean working tree on `develop`**
+
+Run: `git status && git rev-parse --abbrev-ref HEAD`
+Expected: `nothing to commit, working tree clean` and current branch `develop`.
+
+- [ ] **Step 2: Create and switch to the feature branch**
+
+Run: `git checkout -b feature/docker-distribution`
+Expected: `Switched to a new branch 'feature/docker-distribution'`
+
+---
+
+## Task 1: Gitignore `.env`
+
+**Files:**
+- Modify: `.gitignore` (append at end)
+
+- [ ] **Step 1: Append `.env` rule**
+
+Append these lines to the end of `.gitignore`:
+
+```gitignore
+
+# Docker self-host runtime config (copy of .env.example)
+.env
+```
+
+(Leading blank line keeps the section separated from the prior block.)
+
+- [ ] **Step 2: Verify it doesn't ignore `.env.example`**
+
+Run: `git check-ignore -v .env.example`
+Expected: exit code `1` and no output (file is NOT ignored). If it shows a match, the rule is wrong — `.env` (no leading dot-glob) shouldn't catch `.env.example`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(docker): gitignore .env runtime config"
+```
+
+---
+
+## Task 2: Create `.dockerignore`
+
+**Files:**
+- Create: `.dockerignore` (repo root)
+
+- [ ] **Step 1: Write the file**
+
+Create `.dockerignore` with:
+
+```
+**/bin
+**/obj
+**/.vs
+**/.git
+**/node_modules
+docs
+screenshots
+Server.Tests
+*.md
+.github
+.env
+.env.*
+!.env.example
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .dockerignore
+git commit -m "chore(docker): add .dockerignore"
+```
+
+---
+
+## Task 3: Create `.env.example`
+
+**Files:**
+- Create: `.env.example` (repo root)
+
+- [ ] **Step 1: Write the file**
+
+Create `.env.example` with:
+
+```bash
+# Copy to .env and edit. .env is gitignored.
+
+# Bundled SQL Server SA password. SQL Server requires 8+ chars,
+# mix of upper/lower/digit/symbol.
+MSSQL_SA_PASSWORD=ChangeMe.Strong-Password-123!
+
+# Public URL Timinute is reachable on. MUST be https in production
+# and MUST exactly match the URL your reverse proxy serves (no trailing slash).
+IdentityServer__Authority=https://timinute.example.com
+
+# Host port. Container always listens on 8080 internally.
+TIMINUTE_PORT=8080
+
+# Image tag: `latest` (release), `develop` (preview), or a pinned version like `2.1.0`.
+TIMINUTE_TAG=latest
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "chore(docker): add .env.example template"
+```
+
+---
+
+## Task 4: Add `ForwardedHeaders` middleware to `Program.cs`
+
+**Files:**
+- Modify: `Timinute/Server/Program.cs` (add using, add Configure call before `builder.Build()`, add `UseForwardedHeaders` before `UseHttpsRedirection`)
+
+**Why:** The default ASP.NET `ASPNETCORE_FORWARDEDHEADERS_ENABLED` env var auto-enables the middleware with `KnownProxies` limited to loopback. Inside a Docker network, the reverse proxy isn't loopback, so `X-Forwarded-Proto` would be dropped and `IdentityServer` would see `http://` instead of the issuer's `https://`. Configure explicitly so that `KnownNetworks` and `KnownProxies` are cleared — accepting forwarded headers from any source, which is safe inside a private Docker network behind a single reverse proxy.
+
+- [ ] **Step 1: Add the namespace import**
+
+At the top of `Timinute/Server/Program.cs`, after the existing `using Microsoft.AspNetCore.*` block (around line 4), add:
+
+```csharp
+using Microsoft.AspNetCore.HttpOverrides;
+```
+
+- [ ] **Step 2: Register the options before `builder.Build()`**
+
+In `Timinute/Server/Program.cs`, immediately before `var app = builder.Build();` (around line 104), insert:
+
+```csharp
+// Reverse-proxy support. Docker users terminate TLS upstream; we trust
+// X-Forwarded-* from any source inside the private container network.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                             | ForwardedHeaders.XForwardedProto
+                             | ForwardedHeaders.XForwardedHost;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
+```
+
+- [ ] **Step 3: Wire the middleware into the pipeline**
+
+In the same file, immediately before `app.UseHttpsRedirection();` (currently line 128 — line number will shift up by the lines added in Step 2), insert:
+
+```csharp
+app.UseForwardedHeaders();
+```
+
+The pipeline order must be: `UseForwardedHeaders` → `UseHttpsRedirection` → … → `UseIdentityServer` → `UseAuthentication`. Adding it before `UseHttpsRedirection` satisfies that.
+
+- [ ] **Step 4: Build and verify no compile errors**
+
+Run: `dotnet build Timinute.sln --configuration Release`
+Expected: `Build succeeded`. Zero errors. Warnings are fine.
+
+- [ ] **Step 5: Run existing tests, confirm no regressions**
+
+Run: `dotnet test Timinute.sln --configuration Release --no-build`
+Expected: all existing tests pass.
+
+- [ ] **Step 6: Smoke-test locally**
+
+Run: `dotnet run --project Timinute/Server/Timinute.Server.csproj`
+Expected: app starts, no startup exceptions, `https://localhost:7047` serves the landing page. Stop with `Ctrl+C`.
+
+(This validates the middleware insertion didn't break the dev-mode pipeline. Full reverse-proxy behavior is verified later in the compose smoke test.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Timinute/Server/Program.cs
+git commit -m "feat(server): explicit ForwardedHeaders for reverse-proxy compatibility"
+```
+
+---
+
+## Task 5: Add config-gated auto-migrate to `Program.cs`
+
+**Files:**
+- Modify: `Timinute/Server/Program.cs` (insert after `var app = builder.Build();`)
+
+**Why:** Docker users need the app to apply pending EF migrations on container start — there's no path to run `dotnet ef` against the containerized DB from outside. Gate behind a config flag (`DatabaseMigrationOnStartup`, default `true`) so multi-replica or DBA-managed setups can disable it. Dev users on `dotnet run` keep their existing flow but get the same idempotent migration call for free — `MigrateDatabase.ps1` continues to work for the "I haven't yet run the app" case.
+
+- [ ] **Step 1: Insert the migration block**
+
+In `Timinute/Server/Program.cs`, immediately after `var app = builder.Build();` (around line 104 from the previous task — line number will have shifted), insert:
+
+```csharp
+
+if (app.Configuration.GetValue("DatabaseMigrationOnStartup", true))
+{
+    using var scope = app.Services.CreateScope();
+    scope.ServiceProvider.GetRequiredService<ApplicationDbContext>()
+         .Database.Migrate();
+}
+
+```
+
+`Timinute.Server.Data` (which exports `ApplicationDbContext`) is already imported at the top of the file (line 11). `Microsoft.EntityFrameworkCore` is already imported (line 5).
+
+- [ ] **Step 2: Build and verify no compile errors**
+
+Run: `dotnet build Timinute.sln --configuration Release`
+Expected: `Build succeeded`.
+
+- [ ] **Step 3: Run existing tests, confirm no regressions**
+
+Run: `dotnet test Timinute.sln --configuration Release --no-build`
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Smoke-test locally (idempotent migrate)**
+
+Run: `dotnet run --project Timinute/Server/Timinute.Server.csproj`
+Expected: app starts. Check console output: should see EF Core log lines mentioning `Applying migration` only if the dev SQL container has un-applied migrations; otherwise no migration logs. App reachable at `https://localhost:7047`. Stop with `Ctrl+C`.
+
+- [ ] **Step 5: Smoke-test the disable flag**
+
+Run: `dotnet run --project Timinute/Server/Timinute.Server.csproj --no-launch-profile -- --DatabaseMigrationOnStartup=false` (or set `DatabaseMigrationOnStartup=false` in environment, then `dotnet run`).
+Expected: app starts. Zero EF Core migration log lines. (If your dev DB was already up-to-date in Step 4 there'd be no migration logs there either, so this is a confirming-no-attempt smoke, not a hard differentiator. Look for the explicit `Migrate` activity to be absent.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Program.cs
+git commit -m "feat(server): auto-apply EF migrations on startup, gated by config"
+```
+
+---
+
+## Task 6: Create the `Dockerfile`
+
+**Files:**
+- Create: `Dockerfile` (repo root)
+
+- [ ] **Step 1: Write the file**
+
+Create `Dockerfile` at the repo root with:
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /src
+
+# csproj-only first → restore layer caches well
+COPY Timinute.sln ./
+COPY Timinute/Server/Timinute.Server.csproj  Timinute/Server/
+COPY Timinute/Client/Timinute.Client.csproj  Timinute/Client/
+COPY Timinute/Shared/Timinute.Shared.csproj  Timinute/Shared/
+RUN dotnet restore Timinute/Server/Timinute.Server.csproj -a $TARGETARCH
+
+COPY . .
+RUN dotnet publish Timinute/Server/Timinute.Server.csproj \
+        -c Release -a $TARGETARCH --no-restore -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+USER app
+COPY --from=build --chown=app:app /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080 \
+    DatabaseMigrationOnStartup=true
+EXPOSE 8080
+VOLUME ["/keys"]
+ENTRYPOINT ["dotnet", "Timinute.Server.dll"]
+```
+
+- [ ] **Step 2: Verify Docker is available and buildx is on**
+
+Run: `docker buildx version`
+Expected: prints version (e.g., `github.com/docker/buildx v0.14.0 …`). If missing, follow Docker Desktop install or enable the buildx CLI plugin.
+
+- [ ] **Step 3: Native-arch build smoke test**
+
+Run: `docker build -t timinute:dev .`
+Expected: builds successfully on the host's native architecture; final image around 280–340 MB. Note the digest.
+
+- [ ] **Step 4: Verify the image runs and dies cleanly without a reachable DB**
+
+Run: `docker run --rm -e ConnectionStrings__DefaultConnection="Server=127.0.0.1,1;Database=x;User Id=sa;Password=ChangeMe.Strong-Password-123!;TrustServerCertificate=True;Encrypt=True" timinute:dev`
+Expected: the container starts, attempts to apply migrations against the unreachable DB, throws a SQL-connection exception, and exits with non-zero. This confirms the migration block fires and the app entrypoint is wired correctly. (Real DB connectivity is tested in the compose smoke test in Task 8.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat(docker): multi-stage Dockerfile on aspnet:10.0"
+```
+
+---
+
+## Task 7: Create the `docker-compose.yml`
+
+**Files:**
+- Create: `docker-compose.yml` (repo root)
+
+- [ ] **Step 1: Write the file**
+
+Create `docker-compose.yml` at the repo root with:
+
+```yaml
+name: timinute
+
+services:
+  app:
+    image: ghcr.io/jame581/timinute:${TIMINUTE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: >-
+        Server=db,1433;Database=Timinute;User Id=sa;
+        Password=${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env};
+        TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=true
+      IdentityServer__Authority: ${IdentityServer__Authority:?set IdentityServer__Authority in .env}
+    ports:
+      - "${TIMINUTE_PORT:-8080}:8080"
+    volumes:
+      - timinute-keys:/keys
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env}
+      MSSQL_PID: Express
+    volumes:
+      - timinute-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -No -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+volumes:
+  timinute-keys:
+  timinute-data:
+```
+
+- [ ] **Step 2: Validate the compose file parses**
+
+Run: `docker compose config`
+Expected: prints the resolved compose config to stdout (or warns about missing `.env` variables — that's fine, Step 3 fixes it). No "yaml: …" or "schema validation" errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(docker): compose bundle with sql server 2025"
+```
+
+---
+
+## Task 8: Local end-to-end smoke test
+
+**Files:** none — verification only
+
+This task does not produce a commit. It exercises Tasks 2–7 together to catch any integration issues before adding CI and docs.
+
+- [ ] **Step 1: Set up local `.env`**
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env`:
+- `MSSQL_SA_PASSWORD=` set to any 8+ char password with mixed case, digit, symbol (e.g. `Local.Test-Pw-123!`).
+- `IdentityServer__Authority=` set to `https://localhost:8080`.
+- `TIMINUTE_TAG=` change to `dev` (matches the local image tag from Task 6 step 3).
+- `TIMINUTE_PORT=` leave at `8080`.
+
+- [ ] **Step 2: Point compose at the local image**
+
+The compose file pulls `ghcr.io/jame581/timinute:${TIMINUTE_TAG}` — but the image hasn't been pushed yet. For this smoke test, override locally by setting `image: timinute:dev` in compose, OR re-tag your local image:
+
+```bash
+docker tag timinute:dev ghcr.io/jame581/timinute:dev
+```
+
+- [ ] **Step 3: Bring up the stack**
+
+Run: `docker compose up -d`
+Expected: `db` container starts and becomes healthy within ~30s; `app` container starts after that. Both report `healthy`/`running` in `docker compose ps`.
+
+- [ ] **Step 4: Watch the app logs for the startup migration**
+
+Run: `docker compose logs app --tail=200`
+Expected: EF Core log lines indicating migrations applied (since this is a fresh DB). No exceptions. Final line: `Now listening on: http://[::]:8080`.
+
+- [ ] **Step 5: Hit the app**
+
+Open: `http://localhost:8080` in a browser.
+Expected: Timinute landing page renders. (Browser will warn about HTTP on a normally-https origin; ignore for local smoke. Real production needs the reverse-proxy https.)
+
+- [ ] **Step 6: Register a user and track a task**
+
+Manual: register a new account through the UI, log in, create a project, start the stopwatch, stop it, confirm the task appears in the tracked-tasks list.
+Expected: full happy path works.
+
+- [ ] **Step 7: Restart-survival test**
+
+Run: `docker compose down && docker compose up -d`
+Then log back in with the same credentials. Open the tracked-tasks page.
+Expected: user still exists; tracked task still present; user did not have to re-register. Confirms both `timinute-data` (DB) and `timinute-keys` (IdentityServer signing) volumes persist.
+
+- [ ] **Step 8: Fresh-DB test**
+
+Run: `docker compose down -v && docker compose up -d`
+Expected: both named volumes are destroyed; on restart, DB is fresh, migrations apply cleanly, app starts without errors. No user/data carryover.
+
+- [ ] **Step 9: Tear down**
+
+Run: `docker compose down -v`
+Then revert any compose edits made in Step 2 (the override was only for local testing — the committed compose pulls from ghcr).
+
+- [ ] **Step 10: If `sqlcmd` healthcheck failed**
+
+If the SQL Server 2025 image relocated `sqlcmd`, the `db` healthcheck will time out. Replace the healthcheck `test` block in `docker-compose.yml` with a TCP probe:
+
+```yaml
+test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/1433' || exit 1"]
+```
+
+Then commit that fix:
+
+```bash
+git add docker-compose.yml
+git commit -m "fix(docker): swap sql healthcheck to tcp probe (mssql-tools path moved)"
+```
+
+Only do this step if Step 3 failed with `db` stuck in `unhealthy`/`starting`.
+
+---
+
+## Task 9: Create `.github/workflows/docker-publish.yml`
+
+**Files:**
+- Create: `.github/workflows/docker-publish.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/docker-publish.yml` with:
+
+```yaml
+name: Docker Publish
+
+on:
+  push:
+    tags: ['v*']
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jame581/timinute
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/develop' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 2: Commit and push the feature branch**
+
+```bash
+git add .github/workflows/docker-publish.yml
+git commit -m "ci(docker): publish multi-arch image to ghcr"
+git push -u origin feature/docker-distribution
+```
+
+- [ ] **Step 3: Trigger the workflow manually from the feature branch**
+
+Run: `gh workflow run docker-publish.yml --ref feature/docker-distribution`
+Expected: workflow run starts. Get the run URL:
+
+```bash
+gh run list --workflow=docker-publish.yml --branch feature/docker-distribution --limit 1
+```
+
+Open the run in browser or `gh run watch <run-id>`.
+
+- [ ] **Step 4: Verify the manual run succeeds**
+
+Expected: all steps green within ~10–15 minutes (arm64 emulation is slow on the first uncached build). The `Extract metadata` step's output should show only ad-hoc tags (no `:latest`, no `:develop`, since this is a `workflow_dispatch` from a non-default branch). The image is pushed to GHCR.
+
+- [ ] **Step 5: Confirm the image is at GHCR**
+
+Open: `https://github.com/jame581/Timinute/pkgs/container/timinute`
+Expected: a new manifest with both `linux/amd64` and `linux/arm64` platforms shown.
+
+If the workflow failed: read the failing step's logs, fix the workflow file, recommit, force-push, re-run. Common issues:
+- Permissions: PR may need `packages: write` granted on the repo settings for `GITHUB_TOKEN` (Settings → Actions → General → Workflow permissions → "Read and write").
+- arm64 timeout: bump `runs-on` to `ubuntu-latest-l` (if available) or accept the slow first build — subsequent builds use `cache-to: type=gha`.
+
+- [ ] **Step 6: (Optional) Pull the pushed image and re-run the Task 8 smoke**
+
+If you want to validate the GHCR-pushed image end-to-end, update local `.env` `TIMINUTE_TAG=<the sha-XXXXXX tag the workflow used>` and re-run `docker compose up -d`. This is belt-and-suspenders; the local image already passed.
+
+---
+
+## Task 10: Create `docs/DOCKER.md`
+
+**Files:**
+- Create: `docs/DOCKER.md`
+
+- [ ] **Step 1: Write the file**
+
+Create `docs/DOCKER.md` with:
+
+````markdown
+# Running Timinute with Docker
+
+Timinute publishes a multi-arch Docker image (`linux/amd64` + `linux/arm64`) to GitHub Container Registry. The bundled `docker-compose.yml` starts the app alongside a SQL Server container for a 5-minute self-host experience. For production you typically replace the bundled SQL with your own and run Timinute behind a reverse proxy that handles TLS.
+
+## Quick start
+
+```bash
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
+cp .env.example .env
+# edit .env: set MSSQL_SA_PASSWORD and IdentityServer__Authority
+docker compose up -d
+```
+
+The app comes up on `http://localhost:8080` (configurable via `TIMINUTE_PORT`). For production, put a reverse proxy in front with a real TLS cert and set `IdentityServer__Authority` to the public https URL.
+
+## Image tags
+
+| Tag                   | Channel        | When it advances                     |
+|-----------------------|----------------|--------------------------------------|
+| `latest`              | Stable release | On every `v*` git tag                |
+| `2.1.0`, `2.1`, `2`   | Pinned release | On the corresponding `v*` git tag    |
+| `develop`             | Preview        | On every push to the `develop` branch |
+| `@sha256:…`           | Digest pin     | Never moves — recommended for production |
+
+Pin by digest in production:
+
+```yaml
+image: ghcr.io/jame581/timinute@sha256:abc123…
+```
+
+## Configuration reference
+
+All settings flow through ASP.NET Core's hierarchical config — env vars with `__` between segments override `appsettings.json`. The most-frequently-overridden ones:
+
+| Variable                                       | Default                          | Purpose                                  |
+|------------------------------------------------|----------------------------------|------------------------------------------|
+| `ConnectionStrings__DefaultConnection`         | _(set in compose)_               | SQL Server connection string             |
+| `IdentityServer__Authority`                    | `https://localhost:7047`         | OIDC issuer — must be your public URL    |
+| `DatabaseMigrationOnStartup`                   | `true`                           | Auto-apply EF migrations on container start |
+| `ASPNETCORE_ENVIRONMENT`                       | `Production` (in compose)        | Standard ASP.NET env flag                |
+| `ASPNETCORE_URLS`                              | `http://+:8080`                  | Listen address inside container          |
+| `TrashRetention__Days`                         | `30`                             | Soft-delete retention before hard-purge  |
+| `TrashRetention__PurgeIntervalHours`           | `24`                             | How often the purge service runs         |
+
+## Volumes
+
+| Volume          | Mount path inside container | Holds                                      |
+|-----------------|-----------------------------|--------------------------------------------|
+| `timinute-data` | `/var/opt/mssql`            | SQL Server data + logs (bundled DB only)   |
+| `timinute-keys` | `/keys`                     | IdentityServer signing keys — JWT lifetime depends on these surviving restarts |
+
+**Both must persist.** Losing `timinute-data` means losing all user data. Losing `timinute-keys` invalidates every issued JWT and logs every user out.
+
+### Backing up
+
+```bash
+# Snapshot SQL data
+docker compose exec db bash -c "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"\$MSSQL_SA_PASSWORD\" -No -Q 'BACKUP DATABASE Timinute TO DISK = N\"/var/opt/mssql/data/Timinute.bak\" WITH FORMAT, INIT'"
+docker cp $(docker compose ps -q db):/var/opt/mssql/data/Timinute.bak ./Timinute-$(date +%Y%m%d).bak
+
+# Snapshot signing keys
+docker run --rm -v timinute-keys:/keys -v "$(pwd)":/out alpine tar -czf /out/timinute-keys-$(date +%Y%m%d).tar.gz -C /keys .
+```
+
+## Reverse proxy
+
+The container speaks HTTP only. Put a TLS-terminating reverse proxy in front of it. Three examples:
+
+### Caddy (most ergonomic)
+
+```caddyfile
+timinute.example.com {
+    reverse_proxy timinute-app:8080
+}
+```
+
+Caddy auto-provisions a Let's Encrypt cert and forwards `X-Forwarded-*` headers correctly out of the box. Add Caddy as a third service in compose, or run it as a separate stack with a shared external Docker network.
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name timinute.example.com;
+    ssl_certificate     /etc/letsencrypt/live/timinute.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/timinute.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://timinute-app:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+    }
+}
+```
+
+### Traefik labels
+
+Add to the `app` service in compose:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.timinute.rule=Host(`timinute.example.com`)"
+  - "traefik.http.routers.timinute.entrypoints=websecure"
+  - "traefik.http.routers.timinute.tls.certresolver=letsencrypt"
+  - "traefik.http.services.timinute.loadbalancer.server.port=8080"
+```
+
+## External SQL Server
+
+To use an existing SQL Server instead of the bundled one:
+
+1. Comment out the `db` service block in `docker-compose.yml`.
+2. Remove the `depends_on` block on the `app` service.
+3. In `.env`, point the connection string at your server:
+   ```bash
+   # Override the whole connection string. The compose interpolation uses
+   # MSSQL_SA_PASSWORD; set it to anything (it won't be used) or refactor compose
+   # to read a raw connection string env var directly.
+   ```
+   For a non-compose-interpolated string, edit the `app.environment.ConnectionStrings__DefaultConnection` line in compose to:
+   ```yaml
+   ConnectionStrings__DefaultConnection: ${ConnectionStrings__DefaultConnection}
+   ```
+   then put the full string in `.env`.
+4. `MSSQL_SA_PASSWORD` is no longer used; you can remove it from `.env`.
+
+## Upgrading
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Migrations apply on startup. Schema is forward-only — once a newer image migrates the DB, you cannot downgrade to an older image. Back up `timinute-data` before upgrading.
+
+## Multi-replica / DBA-managed deployments
+
+Disable startup migration on the app replicas; run a one-shot migration container before rolling the app:
+
+```bash
+docker run --rm \
+    -e ConnectionStrings__DefaultConnection="…" \
+    -e DatabaseMigrationOnStartup=true \
+    ghcr.io/jame581/timinute:2.2.0
+# ^ exits 0 after migration; app replicas can then start with DatabaseMigrationOnStartup=false
+```
+
+## Troubleshooting
+
+**"Invalid issuer" / "Invalid signature" on login**
+The issuer URL in `IdentityServer__Authority` must EXACTLY match the URL the user's browser is on — protocol (https), host, no trailing slash, correct port. Mismatch causes JWT validation to fail.
+
+**All users get logged out after `docker compose down/up`**
+The `timinute-keys` volume was not persisted. IdentityServer regenerated its signing keys on restart, invalidating every issued token. Confirm the named volume exists: `docker volume ls | grep timinute-keys`.
+
+**SQL container slow on first boot (~30s)**
+Normal. SQL Server initializes `master`, `tempdb`, etc. on first start. The healthcheck has a `start_period: 30s` for this. If it takes longer than 60s, check `docker compose logs db` for password-policy errors.
+
+**App can't reach DB**
+Check `docker compose logs app` for `Microsoft.Data.SqlClient.SqlException`. Typical causes: `MSSQL_SA_PASSWORD` doesn't satisfy SQL's complexity rules (8+ chars, mixed case + digit + symbol); or you changed the SA password but the `timinute-data` volume has the OLD password baked in (recreate with `docker compose down -v`, beware data loss).
+
+**`X-Forwarded-Proto` not honored — OIDC redirect lands on http://**
+Confirm your reverse proxy is actually setting `X-Forwarded-Proto`. nginx requires the explicit `proxy_set_header` line; Caddy and Traefik do it automatically.
+
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/DOCKER.md
+git commit -m "docs(docker): self-host guide with reverse-proxy + upgrade recipes"
+```
+
+---
+
+## Task 11: Update `README.md`
+
+**Files:**
+- Modify: `README.md` (top badge block + new "Run with Docker" section before "Production deployment")
+
+- [ ] **Step 1: Add GHCR badge to the top badge block**
+
+In `README.md`, find the existing badge block (lines 3–6):
+
+```markdown
+[![Release](https://github.com/jame581/Timinute/actions/workflows/release.yml/badge.svg)](https://github.com/jame581/Timinute/actions/workflows/release.yml)
+[![Latest release](https://img.shields.io/github/v/release/jame581/Timinute)](https://github.com/jame581/Timinute/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
+```
+
+Append one more badge line below the `.NET` line:
+
+```markdown
+[![Docker](https://img.shields.io/badge/ghcr.io-jame581%2Ftiminute-blue?logo=docker)](https://github.com/jame581/Timinute/pkgs/container/timinute)
+```
+
+- [ ] **Step 2: Insert "Run with Docker" subsection**
+
+In `README.md`, find the `## Production deployment` heading (around line 87). Immediately before it, insert this section:
+
+````markdown
+## Run with Docker
+
+```bash
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
+cp .env.example .env
+# edit .env: set MSSQL_SA_PASSWORD and IdentityServer__Authority
+docker compose up -d
+```
+
+The app comes up on `http://localhost:8080`. For real deployments, put a TLS-terminating reverse proxy in front and set `IdentityServer__Authority` to the public https URL. Full self-host guide (reverse proxy, external SQL, backups, upgrades, multi-replica): [`docs/DOCKER.md`](docs/DOCKER.md).
+
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add Docker quick-start + GHCR badge"
+```
+
+---
+
+## Task 12: Open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the feature branch**
+
+Run: `git push origin feature/docker-distribution`
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --base develop --title "feat(docker): docker distribution + compose bundle" --body "$(cat <<'EOF'
+## Summary
+
+Adds Docker as a second, equal distribution channel for Timinute alongside the existing per-OS release tarballs. Implements the design in `docs/superpowers/specs/2026-05-15-docker-distribution-design.md`.
+
+- **`Dockerfile`** — multi-stage build on `aspnet:10.0` Debian, non-root `app` user, cross-arch via `$BUILDPLATFORM` + `$TARGETARCH`
+- **`docker-compose.yml`** — app + SQL Server 2025, named volumes for `/keys` + SQL data
+- **`.env.example`** — required secrets / config with `${VAR:?}` guards in compose
+- **`Program.cs`** — explicit `ForwardedHeaders` middleware (loopback-only auto-default doesn't work behind a containerized reverse proxy) and config-gated `Database.Migrate()` at startup (`DatabaseMigrationOnStartup`, default `true`)
+- **`.github/workflows/docker-publish.yml`** — multi-arch build + push to `ghcr.io/jame581/timinute` on `v*` tag (publishes `:latest`, `:X.Y.Z`, `:X.Y`, `:X`) and `develop` push (`:develop` preview channel); `workflow_dispatch` for manual runs
+- **`docs/DOCKER.md`** — full self-host guide
+- **`README.md`** — quick-start + GHCR badge
+
+Existing `release.yml` flow is **unchanged**. Existing `dotnet run` dev workflow is **unchanged at the network layer** (`UseForwardedHeaders` is a no-op without forwarded headers); the only dev-behavior shift is `dotnet run` now auto-applies pending EF migrations, which is idempotent — flip `DatabaseMigrationOnStartup=false` to opt out.
+
+## Test plan
+
+- [ ] `dotnet build Timinute.sln --configuration Release` succeeds
+- [ ] `dotnet test Timinute.sln --configuration Release --no-build` — all existing tests pass
+- [ ] `dotnet run` locally — app starts, migrations apply idempotently, landing page renders at `https://localhost:7047`
+- [ ] `docker build -t timinute:dev .` succeeds on host native arch
+- [ ] `docker compose up -d` on a clean host → app reachable at `http://localhost:8080`, register a user, track a task, see it persisted
+- [ ] `docker compose down && docker compose up -d` → no data loss
+- [ ] `docker compose down -v && docker compose up -d` → fresh DB, migrations apply cleanly
+- [ ] Behind Caddy with real https cert → OIDC login works end-to-end
+- [ ] Restart container → `/keys` survives → users stay logged in
+- [ ] Pull image on `linux/arm64` host → starts and serves correctly
+- [ ] `gh workflow run docker-publish.yml` from feature branch → publishes to GHCR with both arches
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Address review feedback**
+
+For any review comment, fix in a new commit on `feature/docker-distribution`, push, let the reviewer re-look.
+
+- [ ] **Step 4: Merge**
+
+After approval and green CI, merge via the GitHub UI (squash or merge — match the project's existing convention; PRs #40, #41, #42 used "Merge pull request" style, so use the merge-commit option).
+
+- [ ] **Step 5: Verify the `develop` push triggered the workflow**
+
+After merge, the `docker-publish.yml` workflow auto-runs (push to `develop` is a trigger). Watch it:
+
+```bash
+gh run list --workflow=docker-publish.yml --branch develop --limit 1
+```
+
+Expected: green run; `:develop` tag now points at the merged image at GHCR.
+
+---
+
+## Task 13: Post-merge — update the feature roadmap
+
+**Files:**
+- Modify: `docs/superpowers/plans/feature-roadmap.md`
+
+This task runs after Task 12 merges. It's bookkeeping for the project's roadmap doc.
+
+- [ ] **Step 1: Update the "Recently shipped" section**
+
+In `docs/superpowers/plans/feature-roadmap.md`, find the section `## Recently shipped (v2.1, 2026-04-29)` and add a new section above it (or update the heading if appropriate) — the format is one section per release:
+
+```markdown
+## Recently shipped (post-v2.1, develop)
+
+| Feature | PRs |
+|---------|-----|
+| Docker distribution (image + compose bundle, GHCR multi-arch publish) | #<PR-number-from-Task-12> |
+
+## Recently shipped (v2.1, 2026-04-29)
+…(existing content unchanged)…
+```
+
+- [ ] **Step 2: Update the `_Last reviewed:_` line**
+
+At the top of the file, update `_Last reviewed: 2026-04-29 — after v2.1 release (Settings cluster + dark mode)._` to:
+
+```markdown
+_Last reviewed: 2026-05-15 — after Docker distribution merge._
+```
+
+- [ ] **Step 3: Commit directly to develop (housekeeping)**
+
+This is doc-only and follows the project's "direct merge for housekeeping" policy noted in the roadmap's P1-follow-ups table.
+
+```bash
+git checkout develop
+git pull
+git add docs/superpowers/plans/feature-roadmap.md
+git commit -m "docs(roadmap): docker distribution shipped"
+git push
+```
+
+---
+
+## Out-of-scope notes (do not implement)
+
+The following are explicitly out-of-scope per the spec; do NOT add them to this implementation:
+
+- Hadolint Dockerfile lint job in `build_test.yml`
+- Cosign image signing / SBOM attestation
+- Separate migration-runner container
+- Helm chart / Kubernetes manifests
+- Docker Hub mirror
+- `PathBase` / subpath hosting
+- SQLite / Postgres provider support
+- `linux/arm/v7`
+- Channel-pinning UX beyond what semver gives us
+
+Each of the above can be its own follow-up spec if user demand surfaces.

--- a/docs/superpowers/specs/2026-05-15-docker-distribution-design.md
+++ b/docs/superpowers/specs/2026-05-15-docker-distribution-design.md
@@ -1,0 +1,335 @@
+# Docker Distribution — Design
+
+_Spec date: 2026-05-15._
+
+## Purpose
+
+Add Docker as a second, equal distribution channel for Timinute alongside the existing per-OS release bundles. Goal: a self-hoster can stand up Timinute with three commands.
+
+The existing GitHub Releases flow (linux-x64 + win-x64 tarballs from `release.yml`) is unchanged. This work is purely additive.
+
+## Decisions
+
+| Axis | Choice |
+|------|--------|
+| Scope | Image **+** repo-shipped `docker-compose.yml` (app + SQL Server bundle) |
+| DB migrations | Auto-apply on container startup, gated by `DatabaseMigrationOnStartup` (default `true`) |
+| Base image | `mcr.microsoft.com/dotnet/aspnet:10.0` (Debian) |
+| Architectures | `linux/amd64` + `linux/arm64` |
+| Registry | GHCR — `ghcr.io/jame581/timinute` |
+| Image tag format | Unprefixed semver (Docker convention) — `:latest`, `:2.1.0`, `:2.1`, `:2`, `:develop` |
+| Publish trigger | `v*` tag → `:latest` + `:X.Y.Z` + `:X.Y` + `:X`; `develop` push → `:develop` |
+| HTTPS | HTTP-only in container; user terminates TLS upstream; `ForwardedHeaders` middleware explicit in code |
+| Secrets | `.env.example` checked in; user copies to gitignored `.env` |
+
+## Architecture overview
+
+### New files
+
+| Path | Purpose |
+|------|---------|
+| `Dockerfile` (repo root) | Multi-stage build: SDK restore/publish → aspnet runtime. Non-root `app` user. Exposes 8080. Cross-arch via `$BUILDPLATFORM` + `$TARGETARCH`. |
+| `.dockerignore` | Strips `bin/`, `obj/`, `.vs/`, `.git/`, `docs/`, `screenshots/`, `Server.Tests/`, `*.md`, etc. from build context. |
+| `docker-compose.yml` (repo root) | Two services (`app`, `db`), two named volumes (`timinute-keys`, `timinute-data`), env from `.env`. |
+| `.env.example` | Placeholders for `MSSQL_SA_PASSWORD`, `IdentityServer__Authority`, `TIMINUTE_PORT`, `TIMINUTE_TAG`. |
+| `.github/workflows/docker-publish.yml` | Multi-arch build + push to GHCR on `v*` tag and `develop` push. Also `workflow_dispatch` for manual CI test. |
+| `docs/DOCKER.md` | Full self-host guide. |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `Timinute/Server/Program.cs` | (1) Configure `ForwardedHeadersOptions` and call `app.UseForwardedHeaders()` early in the pipeline. (2) Add startup migration gated by `DatabaseMigrationOnStartup` config (default `true`). |
+| `README.md` | New "Run with Docker" subsection above "Production deployment"; GHCR badge in the badge block. |
+| `docs/superpowers/plans/feature-roadmap.md` | After merge: add a "Docker distribution" row to "Recently shipped." |
+| `.gitignore` | Add `.env`. |
+
+### Not touched
+
+- `release.yml` — unchanged. Docker pipeline is a separate workflow.
+- `build_test.yml` — unchanged.
+- `scripts/SetupDockerSql.ps1`, `scripts/MigrateDatabase.ps1` — kept; they serve the dev-workflow audience, not the self-host audience.
+
+## File contents
+
+### `Dockerfile`
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /src
+
+# csproj-only first → restore layer caches well
+COPY Timinute.sln ./
+COPY Timinute/Server/Timinute.Server.csproj  Timinute/Server/
+COPY Timinute/Client/Timinute.Client.csproj  Timinute/Client/
+COPY Timinute/Shared/Timinute.Shared.csproj  Timinute/Shared/
+RUN dotnet restore Timinute/Server/Timinute.Server.csproj -a $TARGETARCH
+
+COPY . .
+RUN dotnet publish Timinute/Server/Timinute.Server.csproj \
+        -c Release -a $TARGETARCH --no-restore -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+USER app
+COPY --from=build --chown=app:app /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080 \
+    DatabaseMigrationOnStartup=true
+EXPOSE 8080
+VOLUME ["/keys"]
+ENTRYPOINT ["dotnet", "Timinute.Server.dll"]
+```
+
+`$BUILDPLATFORM` + `$TARGETARCH` keeps the SDK stage running native on the buildx host; only the published binaries are cross-targeted. Avoids QEMU-emulated SDK execution which is ~5× slower.
+
+### `docker-compose.yml`
+
+```yaml
+name: timinute
+
+services:
+  app:
+    image: ghcr.io/jame581/timinute:${TIMINUTE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: >-
+        Server=db,1433;Database=Timinute;User Id=sa;
+        Password=${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env};
+        TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=true
+      IdentityServer__Authority: ${IdentityServer__Authority:?set IdentityServer__Authority in .env}
+    ports:
+      - "${TIMINUTE_PORT:-8080}:8080"
+    volumes:
+      - timinute-keys:/keys
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD:?set MSSQL_SA_PASSWORD in .env}
+      MSSQL_PID: Express
+    volumes:
+      - timinute-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -No -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+volumes:
+  timinute-keys:
+  timinute-data:
+```
+
+Notes:
+- `${VAR:?...}` makes compose fail with a clear message if the user skipped `.env` setup.
+- The `sqlcmd` path `/opt/mssql-tools18/bin/sqlcmd` matches SQL Server 2022+ images; if 2025 image relocates it, swap to a TCP probe (`bash -c "</dev/tcp/localhost/1433"`).
+- External-SQL users comment out the `db` service and edit the `ConnectionStrings__DefaultConnection` line. Documented in `DOCKER.md`.
+
+### `.env.example`
+
+```bash
+# Copy to .env and edit. .env is gitignored.
+
+# Bundled SQL Server SA password. SQL Server requires 8+ chars,
+# mix of upper/lower/digit/symbol.
+MSSQL_SA_PASSWORD=ChangeMe.Strong-Password-123!
+
+# Public URL Timinute is reachable on. MUST be https in production
+# and MUST exactly match the URL your reverse proxy serves (no trailing slash).
+IdentityServer__Authority=https://timinute.example.com
+
+# Host port. Container always listens on 8080 internally.
+TIMINUTE_PORT=8080
+
+# Image tag: `latest` (release), `develop` (preview), or a pinned version.
+TIMINUTE_TAG=latest
+```
+
+### `.dockerignore`
+
+```
+**/bin
+**/obj
+**/.vs
+**/.git
+**/node_modules
+docs
+screenshots
+Server.Tests
+*.md
+.github
+.env
+.env.*
+!.env.example
+```
+
+### `Program.cs` changes
+
+**ForwardedHeaders.** Current `ASPNETCORE_FORWARDEDHEADERS_ENABLED` env-var auto-enables the middleware with defaults that only trust loopback. Inside a Docker network, the reverse proxy is not loopback, so X-Forwarded-* headers would be dropped and OIDC issuer validation would fail. Configure explicitly:
+
+```csharp
+builder.Services.Configure<ForwardedHeadersOptions>(o =>
+{
+    o.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                       | ForwardedHeaders.XForwardedProto
+                       | ForwardedHeaders.XForwardedHost;
+    o.KnownNetworks.Clear();   // accept from any network
+    o.KnownProxies.Clear();    // acceptable inside a private Docker network
+});
+
+// In pipeline — BEFORE UseAuthentication / IdentityServer:
+app.UseForwardedHeaders();
+```
+
+**Auto-migrate at startup.** Configurable gate so multi-replica or DBA-managed setups can disable:
+
+```csharp
+if (app.Configuration.GetValue("DatabaseMigrationOnStartup", true))
+{
+    using var scope = app.Services.CreateScope();
+    scope.ServiceProvider.GetRequiredService<ApplicationDbContext>()
+         .Database.Migrate();
+}
+```
+
+Auto-migrate is config-gated (`DatabaseMigrationOnStartup`, default `true`). `UseForwardedHeaders` is unconditional but is a no-op when no `X-Forwarded-*` headers reach the app — which is exactly the `dotnet run` localhost case. So the existing dev workflow is unaffected at the network layer; the only behavior shift for dev users is that `dotnet run` will now also apply pending EF migrations on boot (was previously a manual `MigrateDatabase.ps1` step). Migrations are idempotent and the script remains for any user who wants to opt out via `DatabaseMigrationOnStartup=false`.
+
+### `.github/workflows/docker-publish.yml`
+
+```yaml
+name: Docker Publish
+
+on:
+  push:
+    tags: ['v*']
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        with: { platforms: arm64 }
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jame581/timinute
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/develop' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+`type=semver` strips the `v` prefix by default, so git tag `v2.2.0` → image `:2.2.0` / `:2.2` / `:2` / `:latest`. Docker convention; matches `mcr.microsoft.com/mssql/server:2025-latest` and most upstream images.
+
+### `docs/DOCKER.md` — outline
+
+1. **Quick start** — clone, copy `.env.example`, edit, `docker compose up -d`.
+2. **Configuration reference** — every env var the app reads, with defaults.
+3. **Volumes & data** — what each volume holds, backup/restore commands.
+4. **Reverse proxy examples** — Caddyfile snippet (most ergonomic for self-host), nginx snippet, Traefik labels snippet.
+5. **External SQL Server** — comment out the `db` service, override connection string.
+6. **Upgrading** — `docker compose pull && docker compose up -d`. Forward-only; back-up DB first; migrations bake into the image.
+7. **Disabling auto-migrate** — `DatabaseMigrationOnStartup=false` for multi-replica / DBA-managed setups.
+8. **Troubleshooting** — common errors: OIDC issuer mismatch, lost `/keys` invalidating JWTs, SQL slow first boot, X-Forwarded-Proto misconfig.
+
+### `README.md` change
+
+Insert above "Production deployment":
+
+```markdown
+## Run with Docker
+
+[![GHCR](https://img.shields.io/badge/ghcr.io-jame581%2Ftiminute-blue?logo=docker)](https://github.com/jame581/Timinute/pkgs/container/timinute)
+
+\`\`\`bash
+git clone https://github.com/jame581/Timinute.git
+cd Timinute
+cp .env.example .env
+# edit .env: set MSSQL_SA_PASSWORD and IdentityServer__Authority
+docker compose up -d
+\`\`\`
+
+Full self-host guide (reverse proxy, external SQL, backups, upgrades): [`docs/DOCKER.md`](docs/DOCKER.md).
+```
+
+Plus add the GHCR badge to the top-of-file badge block.
+
+## Versioning & upgrade rules
+
+- Releases (`v*` tag push) → `:latest`, `:X.Y.Z`, `:X.Y`, `:X` all advance.
+- `develop` push → `:develop` advances. Preview channel, at-your-own-risk.
+- Schema is forward-only. Image baked with migrations N can't be downgraded once DB has migrated. Documented under "Upgrading."
+- For deterministic deploys, pin by digest (`ghcr.io/jame581/timinute@sha256:...`). Documented.
+
+## Testing strategy
+
+No new xUnit tests. Both code edits (ForwardedHeaders config, conditional `Database.Migrate()`) are 5-line gates around framework-tested code; unit tests would test the framework, not Timinute.
+
+`workflow_dispatch` on the new workflow allows manual CI test before cutting a real release tag.
+
+**Manual verification checklist (must pass before merge):**
+
+1. `docker compose up -d` on a clean host → app reachable at `http://localhost:8080`; register a user; track a task; see it persisted.
+2. `docker compose down && docker compose up -d` → no data loss.
+3. `docker compose down -v && docker compose up -d` → fresh DB; migrations apply cleanly; app starts without errors.
+4. Behind Caddy with a real https cert → OIDC login works end-to-end (`X-Forwarded-Proto` honored; issuer matches `IdentityServer__Authority`).
+5. Restart container → `/keys` survives → JWT signing keys stable; users stay logged in.
+6. Pull image on `linux/arm64` host (Apple Silicon or Pi 5) → starts and serves correctly.
+7. Upgrade path: pull `:2.1.0`, start; then pull `:2.2.0` (or `:develop`); `docker compose up -d` → migrations apply on startup; no manual intervention.
+
+## Out of scope (v1)
+
+- Hadolint Dockerfile lint job in `build_test.yml`
+- Cosign image signing / SBOM attestation
+- Separate migration-runner container (single-service-per-pod pattern)
+- Helm chart / Kubernetes manifests
+- Docker Hub mirror
+- `PathBase` / subpath hosting
+- SQLite / Postgres provider support
+- `linux/arm/v7` (Pi 3 / older — SQL Server doesn't run there anyway)
+- Channel-pinning UX beyond what semver tags give us
+
+Any of the above can be a follow-up spec if user demand surfaces.
+
+## Risks & open questions
+
+- **`sqlcmd` path in SQL Server 2025 image** — assumed `/opt/mssql-tools18/bin/sqlcmd` per 2022+ convention. If the 2025 image moves it, fallback is a TCP-port probe in the healthcheck. Verified during implementation.
+- **`mcr.microsoft.com/dotnet/aspnet:10.0` non-root `app` user** — assumed pre-created (true since .NET 8). Verified during implementation; trivial to add `RUN useradd app` if not.
+- **Existing dev workflow regression risk** — `UseForwardedHeaders` is unconditional but a no-op without `X-Forwarded-*` headers, so localhost dev is unchanged at the network layer. Default `DatabaseMigrationOnStartup=true` means `dotnet run` will now also apply pending EF migrations on boot — a behavior shift for dev users who relied on `MigrateDatabase.ps1` manually. Acceptable: the script remains, the migration call is idempotent, and the gate flips off via `DatabaseMigrationOnStartup=false`. Call it out in the PR notes so dev users aren't surprised.
+- **Forwarded-headers cleared `KnownProxies` security** — accepting `X-Forwarded-*` from any source is fine inside a closed Docker network but would be a header-spoofing risk if the container were directly internet-exposed. Documented in `DOCKER.md`: "must be behind a reverse proxy in production."


### PR DESCRIPTION
## Summary

Adds Docker as a second, equal distribution channel for Timinute alongside the existing per-OS release tarballs. Implements the design in `docs/superpowers/specs/2026-05-15-docker-distribution-design.md`.

**New artifacts**

- **`Dockerfile`** — multi-stage build on `aspnet:10.0` Debian, non-root `app` user, cross-arch via `$BUILDPLATFORM` + `$TARGETARCH`. `/keys` is pre-created and chowned for the runtime user.
- **`docker-compose.yml`** — app + SQL Server 2025, named volumes for `/keys` + SQL data. `${VAR:?}` guards make `.env`-missing errors loud.
- **`.env.example`** — required secrets + config with documented placeholders.
- **`.github/workflows/docker-publish.yml`** — multi-arch build + push to `ghcr.io/jame581/timinute` on `v*` tag (publishes `:latest`, `:X.Y.Z`, `:X.Y`, `:X`) and `develop` push (`:develop` preview channel); `workflow_dispatch` for manual runs once the workflow lands on master.
- **`docs/DOCKER.md`** — full self-host guide (reverse proxy, external SQL, backups, upgrades, troubleshooting).

**Code changes (`Timinute/Server/Program.cs`)**

Each is a small, config-gated change required for containerised / production deployments. All have zero impact on `dotnet run` localhost dev unless someone sets the gate.

1. Explicit `ForwardedHeaders` middleware (`KnownNetworks` / `KnownProxies` cleared) — the default `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true` auto-config only trusts loopback, which breaks reverse-proxy setups.
2. Auto-apply EF migrations on startup, gated by `DatabaseMigrationOnStartup` (default `true`).
3. Duende `IdentityServerOptions.KeyManagement.KeyPath = "/keys"` (overridable via `IdentityServer__KeyManagement__KeyPath`). Targeting `IdentityServerOptions`, not `KeyManagementOptions`, because Duende registers an `IPostConfigureOptions<KeyManagementOptions>` that copies from the former and would otherwise overwrite anything we set directly.
4. ASP.NET Core data protection keys persisted to `/keys/data-protection` (overridable via `DataProtection__KeyPath`). Without this, cookies + Duende signing keys become unreadable after every container restart. Pre-existing latent bug that any production deployment would have hit.
5. Cookie policy `SameSite=Lax` with `Secure=SameAsRequest`. Same-origin auth works over both HTTP (smoke / local) and HTTPS (production). The default `SameSite=None` was silently being dropped by browsers in any non-HTTPS context. Pre-existing latent bug.

**Other**

- `.gitignore` adds `.env`.
- `.dockerignore` excludes `bin/`, `obj/`, `Server.Tests/`, `docs/`, `screenshots/`, etc.
- README adds a `Run with Docker` quick-start section + GHCR badge.

Existing `release.yml` flow is **unchanged**. `dotnet run` dev workflow is **unchanged** (`UseForwardedHeaders` is a no-op without forwarded headers; auto-migrate replaces a manual `MigrateDatabase.ps1` step but the script remains for opt-out via `DatabaseMigrationOnStartup=false`).

## Test plan

Local smoke (Task 8 of the implementation plan) — completed successfully:

- [x] `docker build -t timinute:dev .` succeeds on host native arch (linux/amd64)
- [x] `docker compose up -d` → app reachable at `http://localhost:8080`, register a user, track a task, see it persisted
- [x] `docker compose down && docker compose up -d` → no data loss, user stays logged in (data protection keys + IdentityServer keys both survive)
- [x] `docker compose down -v && docker compose up -d` → fresh DB, migrations apply cleanly

Not yet tested (gated on merge):

- [ ] `linux/arm64` cross-build (will be exercised by the workflow on merge to develop)
- [ ] End-to-end behind a real reverse proxy with TLS (Caddy snippet in DOCKER.md is the recommended setup)
- [ ] GHCR push succeeds (workflow auto-fires on `develop` push trigger after merge)

## Known follow-ups

- `workflow_dispatch` can't be triggered from a feature branch — the workflow has to be on the repo's default branch first. The `branches: [develop]` push trigger will fire automatically on merge. The known `build_test.yml` registration tech debt may apply here too; if so, expect the workflow to register but skip the initial run.

Generated with [Claude Code](https://claude.com/claude-code)