### PR TITLE
feat: v2.2 tags/labels and tech-debt sweep

### DIFF
--- a/Timinute/Client.Tests/Components/TagPickerTest.cs
+++ b/Timinute/Client.Tests/Components/TagPickerTest.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Radzen;
+using Timinute.Client.Components;
+using Timinute.Client.Helpers;
+using Timinute.Client.Tests.Helpers;
+using Timinute.Shared.Dtos.Tag;
+using Xunit;
+
+namespace Timinute.Client.Tests.Components
+{
+    public class TagPickerTest : BunitContext
+    {
+        private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+        [Fact]
+        public void RemoveButton_RemovesSelectedTagFromCallback()
+        {
+            RegisterServices(_ => Task.FromResult(OkJson(new List<TagDto>
+            {
+                new() { TagId = "tag-1", Name = "Work", Color = "#111111" },
+                new() { TagId = "tag-2", Name = "Home", Color = "#222222" },
+            })));
+
+            List<string>? changed = null;
+            var cut = Render<TagPicker>(parameters => parameters
+                .Add(p => p.SelectedTagIds, new List<string> { "tag-1" })
+                .Add(p => p.SelectedTagIdsChanged, EventCallback.Factory.Create<List<string>>(this, ids => changed = ids)));
+
+            cut.WaitForElement(".tag-picker__remove").Click();
+            cut.WaitForAssertion(() =>
+            {
+                Assert.NotNull(changed);
+                Assert.Empty(changed!);
+            });
+        }
+
+        [Fact]
+        public void SelectingOption_AddsTagIdToCallback()
+        {
+            RegisterServices(_ => Task.FromResult(OkJson(new List<TagDto>
+            {
+                new() { TagId = "tag-1", Name = "Work", Color = "#111111" },
+                new() { TagId = "tag-2", Name = "Home", Color = "#222222" },
+            })));
+
+            List<string>? changed = null;
+            var cut = Render<TagPicker>(parameters => parameters
+                .Add(p => p.SelectedTagIds, new List<string>())
+                .Add(p => p.SelectedTagIdsChanged, EventCallback.Factory.Create<List<string>>(this, ids => changed = ids)));
+
+            cut.Find(".tag-picker__add").Click();
+            cut.WaitForAssertion(() =>
+                Assert.Contains(
+                    cut.FindAll(".tag-picker__option"),
+                    button => button.TextContent.Contains("Work", StringComparison.OrdinalIgnoreCase)));
+            cut.FindAll(".tag-picker__option")
+                .Single(button => button.TextContent.Contains("Work", StringComparison.OrdinalIgnoreCase))
+                .Click();
+
+            Assert.NotNull(changed);
+            Assert.Single(changed!);
+            Assert.Equal("tag-1", changed[0]);
+        }
+
+        [Fact]
+        public void CreateOption_PostsAndReturnsCreatedTagId()
+        {
+            string? postedColor = null;
+
+            RegisterServices(async request =>
+            {
+                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/Tag")
+                {
+                    return OkJson(new List<TagDto>
+                    {
+                        new() { TagId = "tag-1", Name = "Work", Color = "#111111" },
+                    });
+                }
+
+                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/Tag")
+                {
+                    var create = await request.Content!.ReadFromJsonAsync<CreateTagDto>();
+                    postedColor = create?.Color;
+                    return OkJson(new TagDto
+                    {
+                        TagId = "tag-new",
+                        Name = "Focus",
+                        Color = "#6366F1",
+                    });
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+            List<string>? changed = null;
+            var cut = Render<TagPicker>(parameters => parameters
+                .Add(p => p.SelectedTagIds, new List<string>())
+                .Add(p => p.SelectedTagIdsChanged, EventCallback.Factory.Create<List<string>>(this, ids => changed = ids)));
+
+            cut.Find(".tag-picker__add").Click();
+            cut.WaitForElement(".tag-picker__search").Input("Focus");
+            cut.WaitForElement(".tag-picker__create-color").Change("#00ff88");
+            cut.WaitForElement(".tag-picker__option--create").Click();
+
+            cut.WaitForAssertion(() =>
+            {
+                Assert.NotNull(changed);
+                Assert.Single(changed!);
+                Assert.Equal("tag-new", changed[0]);
+                Assert.Equal("#00ff88", postedColor, ignoreCase: true);
+            });
+        }
+
+        private void RegisterServices(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder)
+        {
+            Services.AddSingleton(new NotificationService());
+
+            var handler = new StubHttpMessageHandler(responder);
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient(Constants.API.ClientName)).Returns(client);
+            Services.AddSingleton(factory.Object);
+        }
+
+        private static HttpResponseMessage OkJson<T>(T payload) =>
+            new(HttpStatusCode.OK) { Content = JsonContent.Create(payload, options: WebJson) };
+    }
+}

--- a/Timinute/Client.Tests/Timinute.Client.Tests.csproj
+++ b/Timinute/Client.Tests/Timinute.Client.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Timinute/Client/Components/Scheduler/EditTrackedTaskForm.razor
+++ b/Timinute/Client/Components/Scheduler/EditTrackedTaskForm.razor
@@ -46,6 +46,14 @@
                             TextProperty="Name" ValueProperty="ProjectId" Class="w-100" />
         </div>
     </div>
+    <div class="row" style="margin-bottom: 16px">
+        <div class="col-md-3">
+            <RadzenLabel Text="Tags" />
+        </div>
+        <div class="col">
+            <TagPicker SelectedTagIds="model.TagIds" SelectedTagIdsChanged="OnTagIdsChanged" />
+        </div>
+    </div>
     <div class="row">
         <div class="col-md-3"></div>
         <div class="col">
@@ -74,11 +82,18 @@
     protected override void OnParametersSet()
     {
         model = TrackedTask;
+        model.TagIds ??= new List<string>();
     }
 
     void OnSubmit(TrackedTask model)
     {
         DialogService.Close(model);
+    }
+
+    private Task OnTagIdsChanged(List<string> tagIds)
+    {
+        model.TagIds = tagIds;
+        return Task.CompletedTask;
     }
 
     async Task OnDeleteClick()

--- a/Timinute/Client/Components/TagPicker.razor
+++ b/Timinute/Client/Components/TagPicker.razor
@@ -1,0 +1,189 @@
+@using System.Net
+@using System.Net.Http.Json
+@using Timinute.Client.Helpers
+@using Timinute.Shared.Dtos.Tag
+
+@inject IHttpClientFactory ClientFactory
+@inject Radzen.NotificationService Notifier
+
+<div class="tag-picker">
+    @foreach (var tag in SelectedTags)
+    {
+        <span class="tag-picker__pill" style="--tag-color: @tag.Color;">
+            <span class="tag-picker__dot" style="background: @tag.Color;"></span>
+            @tag.Name
+            <button class="tag-picker__remove" type="button"
+                    @onclick="() => RemoveTag(tag.TagId)"
+                    aria-label="Remove @tag.Name">×</button>
+        </span>
+    }
+
+    @if (!showDropdown)
+    {
+        <button class="tag-picker__add" type="button" @onclick="OpenDropdown">
+            <AuroraIcons Name="plus" Size="12" />
+            <span>Add tag</span>
+        </button>
+    }
+    else
+    {
+        <div class="tag-picker__dropdown">
+            <input class="tag-picker__search" type="text" placeholder="Search tags…"
+                   @bind="searchText" @bind:event="oninput" @ref="searchInput" />
+
+            @foreach (var tag in FilteredUnselectedTags)
+            {
+                <button class="tag-picker__option" type="button" @onclick="() => SelectTag(tag.TagId)">
+                    <span class="tag-picker__dot" style="background: @tag.Color;"></span>
+                    @tag.Name
+                </button>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(searchText) && !TagNameExists(searchText))
+            {
+                <div class="tag-picker__create-row">
+                    <input class="tag-picker__create-color" type="color" @bind="createColor" aria-label="New tag color" />
+                    <button class="tag-picker__option tag-picker__option--create" type="button" @onclick="CreateAndSelect">
+                        <AuroraIcons Name="plus" Size="12" />
+                        <span>Create "@searchText.Trim()"</span>
+                    </button>
+                </div>
+            }
+
+            @if (!FilteredUnselectedTags.Any() && string.IsNullOrWhiteSpace(searchText))
+            {
+                <div class="tag-picker__empty">No more tags</div>
+            }
+
+            <button class="tag-picker__close" type="button" @onclick="CloseDropdown">Done</button>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public List<string> SelectedTagIds { get; set; } = new();
+    [Parameter] public EventCallback<List<string>> SelectedTagIdsChanged { get; set; }
+
+    private List<TagDto> allTags = new();
+    private bool showDropdown;
+    private string searchText = string.Empty;
+    private string createColor = "#6366F1";
+    private ElementReference searchInput;
+
+    private HttpClient Http => ClientFactory.CreateClient(Constants.API.ClientName);
+
+    private IEnumerable<TagDto> SelectedTags =>
+        allTags.Where(tag => SelectedTagIds.Contains(tag.TagId));
+
+    private IEnumerable<TagDto> FilteredUnselectedTags =>
+        allTags.Where(tag =>
+            !SelectedTagIds.Contains(tag.TagId)
+            && (string.IsNullOrWhiteSpace(searchText) || tag.Name.Contains(searchText.Trim(), StringComparison.OrdinalIgnoreCase)));
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTags();
+    }
+
+    private async Task LoadTags()
+    {
+        try
+        {
+            allTags = await Http.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+        }
+        catch (Exception ex)
+        {
+            allTags = new();
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Could not load tags", ex.Message, 3000);
+        }
+    }
+
+    private async Task OpenDropdown()
+    {
+        showDropdown = true;
+        searchText = string.Empty;
+        createColor = "#6366F1";
+        await Task.Delay(10);
+        try
+        {
+            await searchInput.FocusAsync();
+        }
+        catch
+        {
+            // Ignore focus failures when the input is not available yet.
+        }
+    }
+
+    private void CloseDropdown()
+    {
+        showDropdown = false;
+        searchText = string.Empty;
+    }
+
+    private bool TagNameExists(string tagName) =>
+        allTags.Any(tag => tag.Name.Equals(tagName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    private async Task SelectTag(string tagId)
+    {
+        if (SelectedTagIds.Contains(tagId))
+        {
+            return;
+        }
+
+        var updated = new List<string>(SelectedTagIds) { tagId };
+        await SelectedTagIdsChanged.InvokeAsync(updated);
+    }
+
+    private async Task RemoveTag(string tagId)
+    {
+        var updated = SelectedTagIds.Where(id => id != tagId).ToList();
+        await SelectedTagIdsChanged.InvokeAsync(updated);
+    }
+
+    private async Task CreateAndSelect()
+    {
+        var name = searchText.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        try
+        {
+            var response = await Http.PostAsJsonAsync(
+                Constants.API.Tag.Create,
+                new CreateTagDto { Name = name, Color = createColor });
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                await LoadTags();
+                var existing = allTags.FirstOrDefault(tag => tag.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (existing != null)
+                {
+                    await SelectTag(existing.TagId);
+                    searchText = string.Empty;
+                    createColor = "#6366F1";
+                    return;
+                }
+
+                Notifier.Notify(Radzen.NotificationSeverity.Warning, "Name taken", $"Tag \"{name}\" already exists.", 3000);
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+            var created = await response.Content.ReadFromJsonAsync<TagDto>();
+            if (created != null)
+            {
+                allTags.Add(created);
+                allTags = allTags.OrderBy(tag => tag.Name, StringComparer.OrdinalIgnoreCase).ToList();
+                await SelectTag(created.TagId);
+                searchText = string.Empty;
+                createColor = "#6366F1";
+            }
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Create failed", ex.Message, 3000);
+        }
+    }
+}

--- a/Timinute/Client/Components/TagPicker.razor.css
+++ b/Timinute/Client/Components/TagPicker.razor.css
@@ -1,0 +1,159 @@
+.tag-picker {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.tag-picker__pill {
+    --_tag-color: var(--tag-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: color-mix(in srgb, var(--_tag-color) 14%, transparent);
+    color: var(--_tag-color);
+    border: 1px solid color-mix(in srgb, var(--_tag-color) 34%, transparent);
+    border-radius: var(--r-pill);
+    padding: 3px 9px;
+    font: 500 12px var(--font-sans);
+}
+
+.tag-picker__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+
+.tag-picker__remove {
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    opacity: 0.7;
+    padding: 0 0 0 2px;
+}
+
+.tag-picker__remove:hover {
+    opacity: 1;
+}
+
+.tag-picker__add {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 28px;
+    border: 1px dashed var(--border);
+    border-radius: var(--r-pill);
+    background: transparent;
+    color: var(--text-mu);
+    padding: 0 10px;
+    font: 500 12px var(--font-sans);
+    cursor: pointer;
+}
+
+.tag-picker__add:hover {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--text) 30%, var(--border));
+}
+
+.tag-picker__dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 60;
+    min-width: 220px;
+    max-height: 250px;
+    overflow-y: auto;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-card);
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tag-picker__search {
+    width: 100%;
+    height: 34px;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--surface);
+    color: var(--text);
+    padding: 0 10px;
+    font: 400 13px var(--font-sans);
+}
+
+.tag-picker__search:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-so);
+}
+
+.tag-picker__option {
+    width: 100%;
+    border: none;
+    border-radius: var(--r-md);
+    background: transparent;
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-align: left;
+    font: 400 13px var(--font-sans);
+    padding: 6px 8px;
+    cursor: pointer;
+}
+
+.tag-picker__option:hover {
+    background: var(--surface-2);
+}
+
+.tag-picker__option--create {
+    color: var(--accent);
+}
+
+.tag-picker__create-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tag-picker__create-color {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: transparent;
+    padding: 2px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.tag-picker__empty {
+    text-align: center;
+    color: var(--text-mu);
+    font: 400 12px var(--font-sans);
+    padding: 8px;
+}
+
+.tag-picker__close {
+    align-self: flex-end;
+    height: 28px;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: transparent;
+    color: var(--text-mu);
+    font: 500 12px var(--font-sans);
+    padding: 0 10px;
+    cursor: pointer;
+}
+
+.tag-picker__close:hover {
+    color: var(--text);
+}

--- a/Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor
+++ b/Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor
@@ -24,6 +24,12 @@
                 </label>
 
             </div>
+            <div class="col-12 mt-2">
+                <label>
+                    Tags:
+                    <TagPicker SelectedTagIds="NewTrackedTask.TagIds" SelectedTagIdsChanged="OnTagIdsChanged" />
+                </label>
+            </div>
             <div class="col-auto">
                 <label>
                     Start Date:

--- a/Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor.cs
+++ b/Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor.cs
@@ -63,7 +63,8 @@ namespace Timinute.Client.Components.TrackedTasks
                 Name = NewTrackedTask.Name,
                 ProjectId = SelectedProjectId,
                 StartDate = NewTrackedTask.StartDate,
-                Duration = NewTrackedTask.Duration
+                Duration = NewTrackedTask.Duration,
+                TagIds = NewTrackedTask.TagIds
             };
 
             try
@@ -83,6 +84,12 @@ namespace Timinute.Client.Components.TrackedTasks
             {
                 notificationService.Notify(NotificationSeverity.Error, "Something happened", ex.Message, 5000);
             }
+        }
+
+        private Task OnTagIdsChanged(List<string> tagIds)
+        {
+            NewTrackedTask.TagIds = tagIds;
+            return Task.CompletedTask;
         }
 
         private void HandleInvalidSubmit(EditContext context)

--- a/Timinute/Client/Helpers/Constants.cs
+++ b/Timinute/Client/Helpers/Constants.cs
@@ -85,6 +85,25 @@ namespace Timinute.Client.Helpers
                 public static string Purge(string id) => $"{Api}/{id}/purge";
             }
 
+            public static class Tag
+            {
+                public const string Api = "Tag";
+
+                public const string Get = Api;
+
+                public const string GetById = $"{Api}/";
+
+                public const string Create = Api;
+
+                public const string Update = Api;
+
+                public const string Delete = Api;
+
+                public static string ForceDelete(string id) => $"{Api}/{id}?force=true";
+
+                public static string DeleteForce(string id) => ForceDelete(id);
+            }
+
             public static class Analytics
             {
                 public const string Api = "Analytics";

--- a/Timinute/Client/Models/TrackedTask.cs
+++ b/Timinute/Client/Models/TrackedTask.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Timinute.Shared.Dtos.Tag;
 using Timinute.Shared.Dtos.TrackedTask;
 
 namespace Timinute.Client.Models
@@ -23,6 +25,10 @@ namespace Timinute.Client.Models
 
         public Project? Project { get; set; }
 
+        public List<string> TagIds { get; set; } = new();
+
+        public List<TagDto> Tags { get; set; } = new();
+
         public string UserId { get; set; } = null!;
 
         public TrackedTask()
@@ -39,6 +45,8 @@ namespace Timinute.Client.Models
             EndDate = trackedTask.EndDate?.LocalDateTime;
             ProjectId = trackedTask.ProjectId;
             UserId = trackedTask.UserId;
+            Tags = trackedTask.Tags;
+            TagIds = trackedTask.Tags.Select(tag => tag.TagId).ToList();
 
             if (trackedTask.Project != null)
             {

--- a/Timinute/Client/Pages/Tags/Tags.razor
+++ b/Timinute/Client/Pages/Tags/Tags.razor
@@ -1,0 +1,272 @@
+@page "/tags"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+
+@using System.Net
+@using System.Net.Http.Json
+@using Timinute.Client.Helpers
+@using Timinute.Shared.Dtos.Tag
+
+@inject IHttpClientFactory ClientFactory
+@inject Radzen.NotificationService Notifier
+@inject Radzen.DialogService DialogService
+
+<PageTitle>Tags</PageTitle>
+
+<div class="aurora-tags-page">
+    <div class="aurora-tags-header">
+        <div>
+            <div class="aurora-tags-title">Tags</div>
+            <div class="aurora-tags-subtitle">Create, color, and manage labels for your tracked tasks.</div>
+        </div>
+        @if (!isCreating)
+        {
+            <AuroraButton Variant="primary" OnClick="OpenCreateRow">
+                <AuroraIcons Name="plus" Size="16" />
+                <span>New tag</span>
+            </AuroraButton>
+        }
+    </div>
+
+    @if (isLoading)
+    {
+        <div class="aurora-tags-loading">Loading…</div>
+    }
+    else
+    {
+        <AuroraCard NoPad="true">
+            @if (isCreating)
+            {
+                <div class="aurora-tags-row aurora-tags-row--edit">
+                    <input class="aurora-tags-input" type="text" maxlength="30" placeholder="Tag name"
+                           @bind="createName" @bind:event="oninput" />
+                    <input class="aurora-tags-color" type="color" @bind="createColor" />
+                    <span class="aurora-tags-row__count"></span>
+                    <div class="aurora-tags-row__actions">
+                        <AuroraButton Variant="primary" Disabled="@string.IsNullOrWhiteSpace(createName)" OnClick="CreateTag">Create</AuroraButton>
+                        <AuroraButton Variant="ghost" OnClick="CancelCreateRow">Cancel</AuroraButton>
+                    </div>
+                </div>
+            }
+
+            @if (tags.Count == 0)
+            {
+                <div class="aurora-tags-empty">No tags yet. Create one to get started.</div>
+            }
+            else
+            {
+                @foreach (var tag in tags)
+                {
+                    if (editingTagId == tag.TagId)
+                    {
+                        <div class="aurora-tags-row aurora-tags-row--edit">
+                            <input class="aurora-tags-input" type="text" maxlength="30" placeholder="Tag name"
+                                   @bind="editName" @bind:event="oninput" />
+                            <input class="aurora-tags-color" type="color" @bind="editColor" />
+                            <span class="aurora-tags-row__count">@tag.TaskCount task@(tag.TaskCount == 1 ? "" : "s")</span>
+                            <div class="aurora-tags-row__actions">
+                                <AuroraButton Variant="primary" Disabled="@string.IsNullOrWhiteSpace(editName)" OnClick="SaveEdit">Save</AuroraButton>
+                                <AuroraButton Variant="ghost" OnClick="CancelEdit">Cancel</AuroraButton>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="aurora-tags-row">
+                            <span class="aurora-tags-pill" style="--tag-color: @tag.Color;">
+                                <span class="aurora-tags-pill__dot" style="background: @tag.Color;"></span>
+                                @tag.Name
+                            </span>
+                            <span class="aurora-tags-row__count">@tag.TaskCount task@(tag.TaskCount == 1 ? "" : "s")</span>
+                            <div class="aurora-tags-row__actions">
+                                <button class="aurora-tags-icon-btn" title="Edit" @onclick="() => OpenEditRow(tag)">
+                                    <AuroraIcons Name="edit" Size="14" />
+                                </button>
+                                <button class="aurora-tags-icon-btn aurora-tags-icon-btn--danger" title="Delete" @onclick="() => ConfirmDelete(tag)">
+                                    <AuroraIcons Name="trash" Size="14" />
+                                </button>
+                            </div>
+                        </div>
+                    }
+                }
+            }
+        </AuroraCard>
+    }
+</div>
+
+@code {
+    private bool isLoading = true;
+    private List<TagDto> tags = new();
+
+    private bool isCreating;
+    private string createName = string.Empty;
+    private string createColor = "#6366F1";
+
+    private string? editingTagId;
+    private string editName = string.Empty;
+    private string editColor = "#6366F1";
+
+    private HttpClient Http => ClientFactory.CreateClient(Constants.API.ClientName);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Reload();
+    }
+
+    private async Task Reload()
+    {
+        isLoading = true;
+        try
+        {
+            tags = await Http.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+        }
+        catch (Exception ex)
+        {
+            tags = new();
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Could not load tags", ex.Message, 4000);
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void OpenCreateRow()
+    {
+        CancelEdit();
+        isCreating = true;
+        createName = string.Empty;
+        createColor = "#6366F1";
+    }
+
+    private void CancelCreateRow()
+    {
+        isCreating = false;
+        createName = string.Empty;
+    }
+
+    private async Task CreateTag()
+    {
+        var name = createName.Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        try
+        {
+            var response = await Http.PostAsJsonAsync(
+                Constants.API.Tag.Create,
+                new CreateTagDto { Name = name, Color = createColor });
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                Notifier.Notify(Radzen.NotificationSeverity.Warning, "Name taken", "A tag with this name already exists.", 3000);
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+            Notifier.Notify(Radzen.NotificationSeverity.Success, "Saved", "Tag created.", 2000);
+            CancelCreateRow();
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Save failed", ex.Message, 4000);
+        }
+    }
+
+    private void OpenEditRow(TagDto tag)
+    {
+        CancelCreateRow();
+        editingTagId = tag.TagId;
+        editName = tag.Name;
+        editColor = tag.Color;
+    }
+
+    private void CancelEdit()
+    {
+        editingTagId = null;
+        editName = string.Empty;
+    }
+
+    private async Task SaveEdit()
+    {
+        if (editingTagId is null)
+        {
+            return;
+        }
+
+        var name = editName.Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        try
+        {
+            var response = await Http.PutAsJsonAsync(
+                $"{Constants.API.Tag.Update}/{editingTagId}",
+                new UpdateTagDto { TagId = editingTagId, Name = name, Color = editColor });
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                Notifier.Notify(Radzen.NotificationSeverity.Warning, "Name taken", "A tag with this name already exists.", 3000);
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+            Notifier.Notify(Radzen.NotificationSeverity.Success, "Saved", "Tag updated.", 2000);
+            CancelEdit();
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Save failed", ex.Message, 4000);
+        }
+    }
+
+    private async Task ConfirmDelete(TagDto tag)
+    {
+        try
+        {
+            var previewResponse = await Http.DeleteAsync($"{Constants.API.Tag.Delete}/{tag.TagId}");
+            previewResponse.EnsureSuccessStatusCode();
+
+            var preview = await previewResponse.Content.ReadFromJsonAsync<TaskCountResponse>();
+            var taskCount = preview?.TaskCount ?? 0;
+
+            if (taskCount > 0)
+            {
+                var confirm = await DialogService.Confirm(
+                    $"This tag is used on {taskCount} task{(taskCount == 1 ? string.Empty : "s")}. Deleting it will remove the tag from those tasks. Continue?",
+                    "Delete tag",
+                    new Radzen.ConfirmOptions { OkButtonText = "Delete", CancelButtonText = "Cancel" });
+
+                if (confirm != true)
+                {
+                    return;
+                }
+            }
+
+            var deleteResponse = await Http.DeleteAsync(Constants.API.Tag.ForceDelete(tag.TagId));
+            deleteResponse.EnsureSuccessStatusCode();
+
+            if (editingTagId == tag.TagId)
+            {
+                CancelEdit();
+            }
+
+            Notifier.Notify(Radzen.NotificationSeverity.Success, "Deleted", $"Tag \"{tag.Name}\" deleted.", 2000);
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Delete failed", ex.Message, 4000);
+        }
+    }
+
+    private sealed class TaskCountResponse
+    {
+        public int TaskCount { get; set; }
+    }
+}

--- a/Timinute/Client/Pages/Tags/Tags.razor.css
+++ b/Timinute/Client/Pages/Tags/Tags.razor.css
@@ -1,0 +1,159 @@
+.aurora-tags-page {
+    padding: 20px 32px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    color: var(--text);
+    font-family: var(--font-sans);
+}
+
+.aurora-tags-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.aurora-tags-title {
+    font: 600 20px var(--font-sans);
+    letter-spacing: -0.3px;
+}
+
+.aurora-tags-subtitle {
+    margin-top: 4px;
+    font: 400 13px var(--font-sans);
+    color: var(--text-mu);
+}
+
+.aurora-tags-loading,
+.aurora-tags-empty {
+    padding: 26px;
+    text-align: center;
+    color: var(--text-mu);
+}
+
+.aurora-tags-row {
+    display: grid;
+    grid-template-columns: minmax(140px, 1fr) auto auto;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-top: 1px solid var(--border);
+}
+
+.aurora-tags-row:first-child {
+    border-top: none;
+}
+
+.aurora-tags-row--edit {
+    grid-template-columns: minmax(120px, 1fr) 44px auto auto;
+}
+
+.aurora-tags-pill {
+    --_tag-color: var(--tag-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    width: fit-content;
+    max-width: 100%;
+    background: color-mix(in srgb, var(--_tag-color) 14%, transparent);
+    color: var(--_tag-color);
+    border: 1px solid color-mix(in srgb, var(--_tag-color) 34%, transparent);
+    border-radius: var(--r-pill);
+    padding: 4px 10px;
+    font: 500 12px var(--font-sans);
+    white-space: nowrap;
+}
+
+.aurora-tags-pill__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.aurora-tags-row__count {
+    font: 400 12px var(--font-sans);
+    color: var(--text-mu);
+    justify-self: end;
+}
+
+.aurora-tags-row__actions {
+    display: inline-flex;
+    gap: 8px;
+    justify-self: end;
+}
+
+.aurora-tags-input {
+    min-width: 0;
+    height: 36px;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--surface);
+    color: var(--text);
+    padding: 0 11px;
+    font: 400 14px var(--font-sans);
+}
+
+.aurora-tags-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-so);
+}
+
+.aurora-tags-color {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: transparent;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.aurora-tags-icon-btn {
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--text-mu);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: border-color .15s ease, background .15s ease, color .15s ease;
+}
+
+.aurora-tags-icon-btn:hover {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--text) 30%, var(--border));
+}
+
+.aurora-tags-icon-btn--danger:hover {
+    color: var(--danger);
+    border-color: color-mix(in srgb, var(--danger) 50%, var(--border));
+    background: color-mix(in srgb, var(--danger) 8%, transparent);
+}
+
+@media (max-width: 900px) {
+    .aurora-tags-page {
+        padding: 12px 16px 16px;
+    }
+
+    .aurora-tags-row {
+        grid-template-columns: 1fr;
+        justify-items: start;
+        gap: 8px;
+    }
+
+    .aurora-tags-row--edit {
+        grid-template-columns: 1fr 44px;
+    }
+
+    .aurora-tags-row__count,
+    .aurora-tags-row__actions {
+        justify-self: start;
+    }
+}

--- a/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor
+++ b/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor
@@ -3,6 +3,7 @@
 
 @using Timinute.Client.Helpers
 @using Timinute.Client.Models
+@using Timinute.Shared.Dtos.Tag
 @using Timinute.Shared.Dtos.TrackedTask
 @using Timinute.Client.Components.Scheduler
 @using Timinute.Client.Components.TrackedTasks
@@ -41,6 +42,22 @@
             <AuroraIcons Name="download" Size="16" />
             <span>Export</span>
         </AuroraButton>
+
+        @if (AllUserTags.Any())
+        {
+            <div class="aurora-tt-filter__tags">
+                @foreach (var tag in AllUserTags)
+                {
+                    var isActive = ActiveTagIds.Contains(tag.TagId);
+                    <button class="aurora-tt-tag-chip @(isActive ? "is-active" : "")"
+                            style="--tag-color: @tag.Color;"
+                            @onclick="() => ToggleTag(tag.TagId)">
+                        <span class="aurora-tt-tag-chip__dot" style="background: @tag.Color;"></span>
+                        @tag.Name
+                    </button>
+                }
+            </div>
+        }
 
         <div style="flex: 1;"></div>
 
@@ -108,6 +125,8 @@
     private bool IsLoading = true;
     private string FilterText = "";
     private List<TrackedTaskDto> AllTasks = new();
+    private List<TagDto> AllUserTags = new();
+    private List<string> ActiveTagIds = new();
 
     private record DayGroup(string Label, DateTime Date, List<TrackedTaskDto> Tasks, TimeSpan Total);
 
@@ -132,7 +151,8 @@
             {
                 source = source.Where(t =>
                     t.Name.Contains(f, StringComparison.OrdinalIgnoreCase)
-                    || (t.Project?.Name?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false));
+                    || (t.Project?.Name?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || t.Tags.Any(tag => tag.Name.Contains(f, StringComparison.OrdinalIgnoreCase)));
             }
 
             return source
@@ -149,7 +169,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await Reload();
+        await Task.WhenAll(Reload(), LoadTags());
     }
 
     private async Task Reload()
@@ -158,7 +178,15 @@
         var client = ClientFactory.CreateClient(Constants.API.ClientName);
         try
         {
-            AllTasks = await client.GetAllPagedAsync<TrackedTaskDto>(Constants.API.TrackedTask.Get);
+            if (ActiveTagIds.Any())
+            {
+                var query = string.Join("&", ActiveTagIds.Select(id => $"tagIds={Uri.EscapeDataString(id)}"));
+                AllTasks = await client.GetAllPagedAsync<TrackedTaskDto>($"{Constants.API.TrackedTask.Get}/search?{query}");
+            }
+            else
+            {
+                AllTasks = await client.GetAllPagedAsync<TrackedTaskDto>(Constants.API.TrackedTask.Get);
+            }
         }
         catch (Exception ex)
         {
@@ -167,6 +195,34 @@
         }
         IsLoading = false;
         StateHasChanged();
+    }
+
+    private async Task LoadTags()
+    {
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            AllUserTags = await client.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+        }
+        catch (Exception ex)
+        {
+            AllUserTags = new();
+            Notifier.Notify(Radzen.NotificationSeverity.Warning, "Could not load tag filters", ex.Message, 3000);
+        }
+    }
+
+    private async Task ToggleTag(string tagId)
+    {
+        if (ActiveTagIds.Contains(tagId))
+        {
+            ActiveTagIds.Remove(tagId);
+        }
+        else
+        {
+            ActiveTagIds.Add(tagId);
+        }
+
+        await Reload();
     }
 
     private async Task EditTask(TrackedTaskDto task)
@@ -186,7 +242,8 @@
                 Name = updated.Name,
                 StartDate = updated.StartDate,
                 EndDate = updated.EndDate,
-                ProjectId = updated.ProjectId
+                ProjectId = updated.ProjectId,
+                TagIds = updated.TagIds
             };
             try
             {

--- a/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
+++ b/Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
@@ -49,6 +49,38 @@
     color: var(--text-dim);
 }
 
+.aurora-tt-filter__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.aurora-tt-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid color-mix(in srgb, var(--tag-color) 40%, transparent);
+    background: transparent;
+    color: var(--tag-color);
+    border-radius: var(--r-pill);
+    padding: 4px 10px;
+    font: 500 12px var(--font-sans);
+    cursor: pointer;
+    transition: background .15s ease;
+}
+
+.aurora-tt-tag-chip.is-active {
+    background: color-mix(in srgb, var(--tag-color) 20%, transparent);
+    font-weight: 600;
+}
+
+.aurora-tt-tag-chip__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+}
+
 .aurora-tt-loading {
     color: var(--text-mu);
     text-align: center;
@@ -177,6 +209,10 @@
     }
 
     .aurora-tt-filter > .aurora-btn--ghost {
+        display: none;
+    }
+
+    .aurora-tt-filter__tags {
         display: none;
     }
 

--- a/Timinute/Client/Shared/AuroraIcons.razor
+++ b/Timinute/Client/Shared/AuroraIcons.razor
@@ -83,6 +83,10 @@
         case "trash":
             <path d="M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13" />
             break;
+        case "tag":
+            <path d="M4.5 7.5A2.5 2.5 0 0 1 7 5h5l7.5 7.5-7.5 7.5H7A2.5 2.5 0 0 1 4.5 17.5z" />
+            <circle cx="8.25" cy="8.25" r="1.1" />
+            break;
         case "more":
             <circle cx="5" cy="12" r="1.3" fill="currentColor" />
             <circle cx="12" cy="12" r="1.3" fill="currentColor" />

--- a/Timinute/Client/Shared/MobileMoreSheet.razor
+++ b/Timinute/Client/Shared/MobileMoreSheet.razor
@@ -45,6 +45,7 @@
     {
         new("Profile",  "profile",   "user"),
         new("Calendar", "scheduler", "calendar"),
+        new("Tags",     "tags",      "tag"),
         new("Trash",    "trash",     "trash"),
     };
 

--- a/Timinute/Client/Shared/NavMenu.razor
+++ b/Timinute/Client/Shared/NavMenu.razor
@@ -93,6 +93,7 @@
         new("Calendar",      "scheduler",       "calendar",  NavLinkMatch.Prefix),
         new("Projects",      "projectmanager",  "folder",    NavLinkMatch.Prefix),
         new("Trash",         "trash",           "trash",     NavLinkMatch.Prefix),
+        new("Tags",          "tags",            "tag",       NavLinkMatch.Prefix),
     };
 
     private static readonly NavItem[] AccountItems =

--- a/Timinute/Client/Shared/Topbar.razor
+++ b/Timinute/Client/Shared/Topbar.razor
@@ -55,6 +55,7 @@
         ["trackedtasks"]           = ("Tracked tasks", "Every minute you've logged."),
         ["scheduler"]              = ("Calendar",      "See your week at a glance."),
         ["projectmanager"]         = ("Projects",      "Keep your work organised."),
+        ["tags"]                   = ("Tags",          "Organize work with labels."),
         ["profile"]                = ("User profile",  "Your account, your data."),
         ["trash"]                  = ("Trash",         "Restore or permanently delete."),
     };

--- a/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -28,6 +29,7 @@ namespace Timinute.Server.Tests.Controllers
 
         private PagingParameters pagingParameters;
 
+        private const string SeedUserId1 = "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d";
         private const string _databaseName = "ProjectController_Test_DB";
         public ProjectControllerTest()
         {
@@ -234,6 +236,51 @@ namespace Timinute.Server.Tests.Controllers
             Assert.NotNull(newlyCreatedProject);
 
             Assert.Equal(projectToCreate.Name, newlyCreatedProject!.Name);
+        }
+
+        [Fact]
+        public async Task Create_Project_Duplicate_Name_Returns_Conflict()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+            ProjectController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var dto = new CreateProjectDto { Name = "Duplicate" };
+
+            var first = await controller.CreateProject(dto);
+            Assert.IsAssignableFrom<OkObjectResult>(first.Result);
+
+            var second = await controller.CreateProject(dto);
+            Assert.IsAssignableFrom<ConflictObjectResult>(second.Result);
+        }
+
+        [Fact]
+        public async Task Create_Project_With_Soft_Deleted_Name_Succeeds()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+            ProjectController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var dto = new CreateProjectDto { Name = "Recreate" };
+
+            var first = await controller.CreateProject(dto);
+            var okResult = first.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+            var firstProject = okResult!.Value as ProjectDto;
+            Assert.NotNull(firstProject);
+
+            var deleteResult = await controller.DeleteProject(firstProject!.ProjectId);
+            Assert.IsType<NoContentResult>(deleteResult);
+
+            var softDeleted = await applicationDbContext.Projects.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(p => p.ProjectId == firstProject.ProjectId);
+            Assert.NotNull(softDeleted);
+            Assert.NotNull(softDeleted!.DeletedAt);
+
+            var second = await controller.CreateProject(dto);
+            Assert.IsAssignableFrom<OkObjectResult>(second.Result);
         }
 
         [Fact]
@@ -457,7 +504,8 @@ namespace Timinute.Server.Tests.Controllers
                 new RepositoryFactory(applicationDbContext),
                 _mapper,
                 new Mock<ILogger<TrackedTaskController>>().Object,
-                taskConfig)
+                taskConfig,
+                applicationDbContext)
             {
                 ControllerContext = new ControllerContext
                 {

--- a/Timinute/Server.Tests/Controllers/TagControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TagControllerTest.cs
@@ -358,6 +358,55 @@ namespace Timinute.Server.Tests.Controllers
         }
 
         [Fact]
+        public async Task Delete_Without_Force_Counts_Soft_Deleted_Task_Associations()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteCountSoftDeleted");
+
+            var tag = new Tag { TagId = "TagIdSoftDeleted", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+            var deletedTask = new TrackedTask
+            {
+                TaskId = "TrackedTaskSoftDeletedTag1",
+                Name = "Deleted Task",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                DeletedAt = start,
+                Tags = new List<Tag> { tag }
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.Add(deletedTask);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var actionResult = await controller.DeleteTag(tag.TagId);
+
+            Assert.IsType<OkObjectResult>(actionResult);
+            var okResult = actionResult as OkObjectResult;
+            Assert.NotNull(okResult);
+            var payload = okResult!.Value;
+            Assert.NotNull(payload);
+
+            int taskCount;
+            if (payload is IDictionary<string, object> dict && dict.TryGetValue("taskCount", out var value))
+            {
+                taskCount = Convert.ToInt32(value);
+            }
+            else
+            {
+                var property = payload.GetType().GetProperty("taskCount");
+                Assert.NotNull(property);
+                taskCount = Convert.ToInt32(property!.GetValue(payload));
+            }
+
+            Assert.Equal(1, taskCount);
+        }
+
+        [Fact]
         public async Task Delete_With_Force_Removes_Tag_And_Leaves_Tasks()
         {
             ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteForce");
@@ -439,7 +488,7 @@ namespace Timinute.Server.Tests.Controllers
                 new Claim(ClaimTypes.Name, "test1@email.com")
             }));
 
-            TagController controller = new(repositoryFactory, _mapper, _loggerMock.Object)
+            TagController controller = new(repositoryFactory, _mapper, _loggerMock.Object, applicationDbContext)
             {
                 ControllerContext = new ControllerContext
                 {

--- a/Timinute/Server.Tests/Controllers/TagControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TagControllerTest.cs
@@ -1,0 +1,453 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Timinute.Server.Controllers;
+using Timinute.Server.Data;
+using Timinute.Server.Models;
+using Timinute.Server.Repository;
+using Timinute.Server.Tests.Helpers;
+using Timinute.Shared.Dtos.Tag;
+using Xunit;
+
+namespace Timinute.Server.Tests.Controllers
+{
+    public class TagControllerTest : ControllerTestBase<TagController>
+    {
+        private const string SeedUserId1 = "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d";
+        private const string _databaseName = "TagController_Test_DB";
+
+        private readonly IMapper _mapper;
+        private readonly Mock<ILogger<TagController>> _loggerMock;
+
+        public TagControllerTest()
+        {
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+            _mapper = new Mapper(configuration);
+
+            _loggerMock = new Mock<ILogger<TagController>>();
+        }
+
+        [Fact]
+        public async Task Get_All_Tags_Returns_Current_User_Sorted_By_Name()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "GetAll");
+
+            var alpha = new Tag { TagId = "TagId1", Name = "Alpha", Color = "#111111", UserId = "ApplicationUser1" };
+            var beta = new Tag { TagId = "TagId2", Name = "Beta", Color = "#222222", UserId = "ApplicationUser1" };
+            var other = new Tag { TagId = "TagId3", Name = "Other", Color = "#333333", UserId = "ApplicationUser2" };
+
+            var start = DateTimeOffset.UtcNow;
+            var task = new TrackedTask
+            {
+                TaskId = "TrackedTaskTag1",
+                Name = "Tagged task",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { beta }
+            };
+
+            applicationDbContext.Tags.AddRange(alpha, beta, other);
+            applicationDbContext.TrackedTasks.Add(task);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var actionResult = await controller.GetTags();
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+
+            Assert.IsAssignableFrom<IEnumerable<TagDto>>(okResult!.Value);
+            var tags = (okResult.Value as IEnumerable<TagDto>)!.ToList();
+
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("Alpha", tags[0].Name);
+            Assert.Equal("Beta", tags[1].Name);
+            Assert.Equal(0, tags[0].TaskCount);
+            Assert.Equal(1, tags[1].TaskCount);
+        }
+
+        [Fact]
+        public async Task Get_Tag_By_Id_Wrong_User_Returns_NotFound()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "GetWrongUser");
+            applicationDbContext.Tags.Add(new Tag
+            {
+                TagId = "TagId1",
+                Name = "Alpha",
+                Color = "#111111",
+                UserId = "ApplicationUser1"
+            });
+            await applicationDbContext.SaveChangesAsync();
+
+            TagController controller = await CreateController(applicationDbContext, "ApplicationUser2");
+
+            var actionResult = await controller.GetTag("TagId1");
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<NotFoundObjectResult>(actionResult.Result);
+        }
+
+        [Fact]
+        public async Task Get_Tag_By_Id_Returns_Dto_And_Task_Count()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "GetSuccess");
+
+            var tag = new Tag
+            {
+                TagId = "TagId1",
+                Name = "Alpha",
+                Color = "#111111",
+                UserId = "ApplicationUser1"
+            };
+            var task = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagGet",
+                Name = "Tagged task",
+                UserId = "ApplicationUser1",
+                StartDate = DateTimeOffset.UtcNow,
+                Duration = TimeSpan.FromHours(1),
+                Tags = new List<Tag> { tag }
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.Add(task);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var actionResult = await controller.GetTag("TagId1");
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+
+            var dto = okResult!.Value as TagDto;
+            Assert.NotNull(dto);
+            Assert.Equal("Alpha", dto!.Name);
+            Assert.Equal(1, dto.TaskCount);
+        }
+
+        [Fact]
+        public async Task Create_Tag_Returns_Dto_And_Persists()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "Create");
+            TagController controller = await CreateController(applicationDbContext);
+
+            var dto = new CreateTagDto { Name = "New tag", Color = "#ABCDEF" };
+            var actionResult = await controller.CreateTag(dto);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var okResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+            Assert.IsAssignableFrom<TagDto>(okResult!.Value);
+
+            var created = okResult.Value as TagDto;
+            Assert.NotNull(created);
+            Assert.Equal(dto.Name, created!.Name);
+            Assert.Equal(dto.Color, created.Color);
+
+            var saved = await applicationDbContext.Tags.FirstOrDefaultAsync(t => t.TagId == created.TagId);
+            Assert.NotNull(saved);
+            Assert.Equal("ApplicationUser1", saved!.UserId);
+        }
+
+        [Fact]
+        public async Task Create_Tag_Duplicate_Name_Returns_Conflict()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+            TagController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var dto = new CreateTagDto { Name = "Duplicate", Color = "#123456" };
+
+            var first = await controller.CreateTag(dto);
+            Assert.IsAssignableFrom<OkObjectResult>(first.Result);
+
+            var second = await controller.CreateTag(dto);
+            Assert.IsAssignableFrom<ConflictObjectResult>(second.Result);
+        }
+
+        [Fact]
+        public async Task Update_Tag_Returns_Updated_Dto()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "Update");
+            applicationDbContext.Tags.Add(new Tag
+            {
+                TagId = "TagId1",
+                Name = "Old",
+                Color = "#111111",
+                UserId = "ApplicationUser1"
+            });
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var update = new UpdateTagDto
+            {
+                TagId = "TagId1",
+                Name = "Updated",
+                Color = "#222222"
+            };
+
+            var actionResult = await controller.UpdateTag("TagId1", update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+            var okResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+
+            var updated = okResult!.Value as TagDto;
+            Assert.NotNull(updated);
+            Assert.Equal(update.Name, updated!.Name);
+            Assert.Equal(update.Color, updated.Color);
+
+            var saved = await applicationDbContext.Tags.FirstOrDefaultAsync(t => t.TagId == update.TagId);
+            Assert.NotNull(saved);
+            Assert.Equal(update.Name, saved!.Name);
+            Assert.Equal(update.Color, saved.Color);
+        }
+
+        [Fact]
+        public async Task Update_Tag_Duplicate_Name_Returns_Conflict()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateDuplicate");
+            applicationDbContext.Tags.AddRange(
+                new Tag
+                {
+                    TagId = "TagId1",
+                    Name = "Old",
+                    Color = "#111111",
+                    UserId = "ApplicationUser1"
+                },
+                new Tag
+                {
+                    TagId = "TagId2",
+                    Name = "Existing",
+                    Color = "#222222",
+                    UserId = "ApplicationUser1"
+                });
+            await applicationDbContext.SaveChangesAsync();
+                applicationDbContext.ChangeTracker.Clear();
+
+                TagController controller = await CreateController(applicationDbContext);
+
+            var update = new UpdateTagDto
+            {
+                TagId = "TagId1",
+                Name = "Existing",
+                Color = "#333333"
+            };
+
+            var actionResult = await controller.UpdateTag("TagId1", update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<ConflictObjectResult>(actionResult.Result);
+        }
+
+        [Fact]
+        public async Task Update_Tag_Wrong_User_Returns_NotFound()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateWrongUser");
+            applicationDbContext.Tags.Add(new Tag
+            {
+                TagId = "TagId1",
+                Name = "Old",
+                Color = "#111111",
+                UserId = "ApplicationUser1"
+            });
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext, "ApplicationUser2");
+
+            var update = new UpdateTagDto
+            {
+                TagId = "TagId1",
+                Name = "Updated",
+                Color = "#222222"
+            };
+
+            var actionResult = await controller.UpdateTag("TagId1", update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<NotFoundObjectResult>(actionResult.Result);
+        }
+
+        [Fact]
+        public async Task Delete_Without_Force_Returns_Task_Count()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteCount");
+
+            var tag = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+            var task1 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTag1",
+                Name = "Task 1",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { tag }
+            };
+            var task2 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTag2",
+                Name = "Task 2",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(2),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(3),
+                Tags = new List<Tag> { tag }
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.AddRange(task1, task2);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var actionResult = await controller.DeleteTag(tag.TagId);
+
+            Assert.IsType<OkObjectResult>(actionResult);
+            var okResult = actionResult as OkObjectResult;
+            Assert.NotNull(okResult);
+            var payload = okResult!.Value;
+            Assert.NotNull(payload);
+
+            int taskCount;
+            if (payload is IDictionary<string, object> dict && dict.TryGetValue("taskCount", out var value))
+            {
+                taskCount = Convert.ToInt32(value);
+            }
+            else
+            {
+                var property = payload.GetType().GetProperty("taskCount");
+                Assert.NotNull(property);
+                taskCount = Convert.ToInt32(property!.GetValue(payload));
+            }
+
+            Assert.Equal(2, taskCount);
+
+            var tagStillThere = await applicationDbContext.Tags.FirstOrDefaultAsync(t => t.TagId == tag.TagId);
+            Assert.NotNull(tagStillThere);
+        }
+
+        [Fact]
+        public async Task Delete_With_Force_Removes_Tag_And_Leaves_Tasks()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteForce");
+
+            var tag = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+            var task1 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTag1",
+                Name = "Task 1",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { tag }
+            };
+            var task2 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTag2",
+                Name = "Task 2",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(2),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(3),
+                Tags = new List<Tag> { tag }
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.AddRange(task1, task2);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TagController controller = await CreateController(applicationDbContext);
+
+            var actionResult = await controller.DeleteTag(tag.TagId, true);
+
+            Assert.IsType<NoContentResult>(actionResult);
+
+            var deletedTag = await applicationDbContext.Tags.FirstOrDefaultAsync(t => t.TagId == tag.TagId);
+            Assert.Null(deletedTag);
+
+            var remainingTasks = await applicationDbContext.TrackedTasks
+                .Where(t => t.TaskId == "TrackedTaskTag1" || t.TaskId == "TrackedTaskTag2")
+                .ToListAsync();
+            Assert.Equal(2, remainingTasks.Count);
+        }
+
+        [Fact]
+        public async Task Delete_Tag_Wrong_User_Returns_NotFound()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "DeleteWrongUser");
+            applicationDbContext.Tags.Add(new Tag
+            {
+                TagId = "TagId1",
+                Name = "Old",
+                Color = "#111111",
+                UserId = "ApplicationUser1"
+            });
+            await applicationDbContext.SaveChangesAsync();
+
+            TagController controller = await CreateController(applicationDbContext, "ApplicationUser2");
+
+            var actionResult = await controller.DeleteTag("TagId1", true);
+
+            Assert.IsType<NotFoundObjectResult>(actionResult);
+        }
+
+        protected override async Task<TagController> CreateController(ApplicationDbContext? applicationDbContext = null, string userId = "ApplicationUser1")
+        {
+            if (applicationDbContext == null)
+            {
+                applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName);
+            }
+
+            var repositoryFactory = new RepositoryFactory(applicationDbContext);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {
+                new Claim("sub", userId),
+                new Claim(ClaimTypes.Name, "test1@email.com")
+            }));
+
+            TagController controller = new(repositoryFactory, _mapper, _loggerMock.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = user }
+                }
+            };
+
+            return controller;
+        }
+    }
+}

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -12,6 +13,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Timinute.Server.Controllers;
 using Timinute.Server.Data;
+using Timinute.Server.Models;
 using Timinute.Server.Models.Paging;
 using Timinute.Server.Repository;
 using Timinute.Server.Tests.Helpers;
@@ -28,6 +30,7 @@ namespace Timinute.Server.Tests.Controllers
 
         private PagingParameters pagingParameters;
 
+        private const string SeedUserId1 = "a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d";
         private const string _databaseName = "TrackedTaskController_Test_DB";
         public TrackedTaskControllerTest()
         {
@@ -284,6 +287,180 @@ namespace Timinute.Server.Tests.Controllers
         }
 
         [Fact]
+        public async Task Create_TrackedTask_With_Tags_Attaches_Tags()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "CreateTags");
+
+            var tag1 = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var tag2 = new Tag { TagId = "TagId2", Name = "Personal", Color = "#222222", UserId = "ApplicationUser1" };
+            applicationDbContext.Tags.AddRange(tag1, tag2);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext);
+            var startDate = DateTimeOffset.UtcNow;
+
+            var trackedTaskToCreate = new CreateTrackedTaskDto
+            {
+                Name = "Tagged task",
+                StartDate = startDate,
+                Duration = TimeSpan.FromHours(1),
+                TagIds = new List<string> { tag1.TagId, tag2.TagId }
+            };
+
+            var actionResult = await controller.CreateTrackedTask(trackedTaskToCreate);
+
+            Assert.NotNull(actionResult);
+            var okActionResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okActionResult);
+
+            var created = okActionResult!.Value as TrackedTaskDto;
+            Assert.NotNull(created);
+            Assert.Equal(2, created!.Tags.Count);
+            Assert.Contains(created.Tags, tag => tag.TagId == tag1.TagId);
+            Assert.Contains(created.Tags, tag => tag.TagId == tag2.TagId);
+
+            var saved = await applicationDbContext.TrackedTasks.Include(t => t.Tags)
+                .FirstOrDefaultAsync(t => t.TaskId == created.TaskId);
+            Assert.NotNull(saved);
+            Assert.Equal(2, saved!.Tags.Count);
+        }
+
+        [Fact]
+        public async Task Create_TrackedTask_With_Unowned_Tag_Skips_Tag()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "CreateUnownedTags");
+
+            var owned = new Tag { TagId = "TagId1", Name = "Owned", Color = "#111111", UserId = "ApplicationUser1" };
+            var unowned = new Tag { TagId = "TagId2", Name = "Other", Color = "#222222", UserId = "ApplicationUser2" };
+            applicationDbContext.Tags.AddRange(owned, unowned);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext);
+            var startDate = DateTimeOffset.UtcNow;
+
+            var trackedTaskToCreate = new CreateTrackedTaskDto
+            {
+                Name = "Tagged task",
+                StartDate = startDate,
+                Duration = TimeSpan.FromHours(1),
+                TagIds = new List<string> { owned.TagId, unowned.TagId }
+            };
+
+            var actionResult = await controller.CreateTrackedTask(trackedTaskToCreate);
+
+            Assert.NotNull(actionResult);
+            var okActionResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okActionResult);
+
+            var created = okActionResult!.Value as TrackedTaskDto;
+            Assert.NotNull(created);
+            Assert.Single(created!.Tags);
+            Assert.Equal(owned.TagId, created.Tags[0].TagId);
+
+            var saved = await applicationDbContext.TrackedTasks.Include(t => t.Tags)
+                .FirstOrDefaultAsync(t => t.TaskId == created.TaskId);
+            Assert.NotNull(saved);
+            Assert.Single(saved!.Tags);
+            Assert.Equal(owned.TagId, saved.Tags.First().TagId);
+        }
+
+        [Fact]
+        public async Task Update_TrackedTask_Replaces_Tags()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+            var tag1 = new Tag { TagId = "TagId1", Name = "First", Color = "#111111", UserId = SeedUserId1 };
+            var tag2 = new Tag { TagId = "TagId2", Name = "Second", Color = "#222222", UserId = SeedUserId1 };
+            var startDate = DateTimeOffset.UtcNow;
+            var task = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagUpdate",
+                Name = "Task",
+                UserId = SeedUserId1,
+                StartDate = startDate,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = startDate.AddHours(1),
+                Tags = new List<Tag> { tag1 }
+            };
+
+            applicationDbContext.Tags.AddRange(tag1, tag2);
+            applicationDbContext.TrackedTasks.Add(task);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var update = new UpdateTrackedTaskDto
+            {
+                TaskId = task.TaskId,
+                Name = task.Name,
+                StartDate = startDate,
+                TagIds = new List<string> { tag2.TagId }
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var saved = await applicationDbContext.TrackedTasks.Include(t => t.Tags)
+                .FirstOrDefaultAsync(t => t.TaskId == task.TaskId);
+            Assert.NotNull(saved);
+            Assert.Single(saved!.Tags);
+            Assert.Equal(tag2.TagId, saved.Tags.First().TagId);
+        }
+
+        [Fact]
+        public async Task Update_TrackedTask_Without_TagIds_Preserves_Existing_Tags()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+            var tag = new Tag { TagId = "TagId1", Name = "First", Color = "#111111", UserId = SeedUserId1 };
+            var startDate = DateTimeOffset.UtcNow;
+            var task = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagPreserve",
+                Name = "Task",
+                UserId = SeedUserId1,
+                StartDate = startDate,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = startDate.AddHours(1),
+                Tags = new List<Tag> { tag }
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.Add(task);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var update = new UpdateTrackedTaskDto
+            {
+                TaskId = task.TaskId,
+                Name = task.Name,
+                StartDate = startDate,
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var saved = await applicationDbContext.TrackedTasks.Include(t => t.Tags)
+                .FirstOrDefaultAsync(t => t.TaskId == task.TaskId);
+            Assert.NotNull(saved);
+            Assert.Single(saved!.Tags);
+            Assert.Equal(tag.TagId, saved.Tags.First().TagId);
+        }
+
+        [Fact]
         public async Task Update_TrackedTask_Another_User_Test()
         {
             ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateAuthTest");
@@ -393,6 +570,166 @@ namespace Timinute.Server.Tests.Controllers
             Assert.NotNull(tasks);
             Assert.Single(tasks!);
             Assert.Equal("TrackedTaskId1", tasks!.First().TaskId);
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_TagId_Returns_Matching_Tasks()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchTagMatch");
+
+            var tag = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var otherTag = new Tag { TagId = "TagId2", Name = "Other", Color = "#222222", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+            var task1 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearch1",
+                Name = "Tagged",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { tag }
+            };
+            var task2 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearch2",
+                Name = "Other",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(2),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(3),
+                Tags = new List<Tag> { otherTag }
+            };
+
+            applicationDbContext.Tags.AddRange(tag, otherTag);
+            applicationDbContext.TrackedTasks.AddRange(task1, task2);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext);
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, null, new List<string> { tag.TagId });
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Single(tasks!);
+            Assert.Equal(task1.TaskId, tasks.First().TaskId);
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_TagId_Excludes_Untagged_Tasks()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchTagExclude");
+
+            var tag = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+            var taggedTask = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearch3",
+                Name = "Tagged",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { tag }
+            };
+            var untaggedTask = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearch4",
+                Name = "Untagged",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(2),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(3)
+            };
+
+            applicationDbContext.Tags.Add(tag);
+            applicationDbContext.TrackedTasks.AddRange(taggedTask, untaggedTask);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext);
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(pagingParams, null, null, null, null, new List<string> { tag.TagId });
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            Assert.Single(tasks!);
+            Assert.DoesNotContain(tasks, t => t.TaskId == untaggedTask.TaskId);
+        }
+
+        [Fact]
+        public async Task Search_Tasks_By_Multiple_TagIds_Uses_Or_Semantics()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "SearchTagOr");
+
+            var tag1 = new Tag { TagId = "TagId1", Name = "Work", Color = "#111111", UserId = "ApplicationUser1" };
+            var tag2 = new Tag { TagId = "TagId2", Name = "Personal", Color = "#222222", UserId = "ApplicationUser1" };
+            var start = DateTimeOffset.UtcNow;
+
+            var task1 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearchOr1",
+                Name = "Task1",
+                UserId = "ApplicationUser1",
+                StartDate = start,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(1),
+                Tags = new List<Tag> { tag1 }
+            };
+
+            var task2 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearchOr2",
+                Name = "Task2",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(2),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(3),
+                Tags = new List<Tag> { tag2 }
+            };
+
+            var task3 = new TrackedTask
+            {
+                TaskId = "TrackedTaskTagSearchOr3",
+                Name = "Task3",
+                UserId = "ApplicationUser1",
+                StartDate = start.AddHours(4),
+                Duration = TimeSpan.FromHours(1),
+                EndDate = start.AddHours(5)
+            };
+
+            applicationDbContext.Tags.AddRange(tag1, tag2);
+            applicationDbContext.TrackedTasks.AddRange(task1, task2, task3);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext);
+            var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+            var actionResult = await controller.SearchTrackedTasks(
+                pagingParams,
+                null,
+                null,
+                null,
+                null,
+                new List<string> { tag1.TagId, tag2.TagId });
+
+            Assert.NotNull(actionResult);
+            var okResult = actionResult.Result as OkObjectResult;
+            var tasks = okResult!.Value as IEnumerable<TrackedTaskDto>;
+            Assert.NotNull(tasks);
+            var list = tasks!.ToList();
+            Assert.Equal(2, list.Count);
+            Assert.Contains(list, t => t.TaskId == task1.TaskId);
+            Assert.Contains(list, t => t.TaskId == task2.TaskId);
+            Assert.DoesNotContain(list, t => t.TaskId == task3.TaskId);
         }
 
         [Fact]
@@ -545,7 +882,7 @@ namespace Timinute.Server.Tests.Controllers
                 .AddInMemoryCollection(new Dictionary<string, string?> { ["TrashRetention:Days"] = "30" })
                 .Build();
 
-            TrackedTaskController controller = new(repositoryFactory, _mapper, _loggerMock.Object, configuration)
+            TrackedTaskController controller = new(repositoryFactory, _mapper, _loggerMock.Object, configuration, applicationDbContext)
             {
                 ControllerContext = new ControllerContext
                 {

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -461,6 +461,57 @@ namespace Timinute.Server.Tests.Controllers
         }
 
         [Fact]
+        public async Task Update_TrackedTask_Response_Includes_Project()
+        {
+            await using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var applicationDbContext = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+            var project = new Project { ProjectId = "ProjectUpdateResponse1", Name = "Project 1", UserId = SeedUserId1 };
+            var startDate = DateTimeOffset.UtcNow;
+            var task = new TrackedTask
+            {
+                TaskId = "TrackedTaskUpdateResponse1",
+                Name = "Task",
+                UserId = SeedUserId1,
+                ProjectId = project.ProjectId,
+                StartDate = startDate,
+                Duration = TimeSpan.FromHours(1),
+                EndDate = startDate.AddHours(1),
+            };
+
+            applicationDbContext.Projects.Add(project);
+            applicationDbContext.TrackedTasks.Add(task);
+            await applicationDbContext.SaveChangesAsync();
+            applicationDbContext.ChangeTracker.Clear();
+
+            TrackedTaskController controller = await CreateController(applicationDbContext, SeedUserId1);
+
+            var update = new UpdateTrackedTaskDto
+            {
+                TaskId = task.TaskId,
+                Name = "Task Updated",
+                StartDate = startDate,
+                ProjectId = project.ProjectId
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(update);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var okResult = actionResult.Result as OkObjectResult;
+            Assert.NotNull(okResult);
+
+            var dto = okResult!.Value as TrackedTaskDto;
+            Assert.NotNull(dto);
+            Assert.Equal(project.ProjectId, dto!.ProjectId);
+            Assert.NotNull(dto.Project);
+            Assert.Equal(project.ProjectId, dto.Project!.ProjectId);
+            Assert.Equal(project.Name, dto.Project.Name);
+        }
+
+        [Fact]
         public async Task Update_TrackedTask_Another_User_Test()
         {
             ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateAuthTest");

--- a/Timinute/Server.Tests/Dtos/TagDtoValidationTest.cs
+++ b/Timinute/Server.Tests/Dtos/TagDtoValidationTest.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Timinute.Shared.Dtos.Tag;
+using Xunit;
+
+namespace Timinute.Server.Tests.Dtos
+{
+    public class TagDtoValidationTest
+    {
+        [Fact]
+        public void CreateTagDto_Whitespace_Name_Fails_Validation()
+        {
+            var dto = new CreateTagDto
+            {
+                Name = "   ",
+                Color = "#123456"
+            };
+
+            var results = Validate(dto);
+
+            Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateTagDto.Name)));
+        }
+
+        [Fact]
+        public void UpdateTagDto_Whitespace_Name_Fails_Validation()
+        {
+            var dto = new UpdateTagDto
+            {
+                TagId = "tag-1",
+                Name = "   ",
+                Color = "#123456"
+            };
+
+            var results = Validate(dto);
+
+            Assert.Contains(results, r => r.MemberNames.Contains(nameof(UpdateTagDto.Name)));
+        }
+
+        [Fact]
+        public void CreateTagDto_Valid_Name_Passes_Validation()
+        {
+            var dto = new CreateTagDto
+            {
+                Name = "Work",
+                Color = "#123456"
+            };
+
+            var results = Validate(dto);
+
+            Assert.Empty(results);
+        }
+
+        private static List<ValidationResult> Validate(object model)
+        {
+            var context = new ValidationContext(model);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(model, context, results, validateAllProperties: true);
+            return results;
+        }
+    }
+}

--- a/Timinute/Server/Controllers/ProjectController.cs
+++ b/Timinute/Server/Controllers/ProjectController.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using System.Text.Json;
 using Timinute.Server.Helpers;
@@ -149,7 +150,15 @@ namespace Timinute.Server.Controllers
                 newProject.Color = ProjectPalette[existingCount % ProjectPalette.Length];
             }
 
-            await projectRepository.Insert(newProject);
+            try
+            {
+                await projectRepository.Insert(newProject);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                logger.LogWarning(ex, "Duplicate project name detected for user {UserId}.", userId);
+                return Conflict(new { message = "A project with this name already exists." });
+            }
             return Ok(mapper.Map<ProjectDto>(newProject));
         }
 
@@ -302,9 +311,25 @@ namespace Timinute.Server.Controllers
 
             var updatedProject = mapper.Map(project, foundProject);
 
-            await projectRepository.Update(updatedProject);
+            try
+            {
+                await projectRepository.Update(updatedProject);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                logger.LogWarning(ex, "Duplicate project name detected for user {UserId}.", userId);
+                return Conflict(new { message = "A project with this name already exists." });
+            }
 
             return Ok(mapper.Map<ProjectDto>(updatedProject));
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            var message = ex.InnerException?.Message ?? ex.Message;
+            return message.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Timinute/Server/Controllers/TagController.cs
+++ b/Timinute/Server/Controllers/TagController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
+using Timinute.Server.Data;
 using Timinute.Server.Helpers;
 using Timinute.Server.Models;
 using Timinute.Server.Repository;
@@ -18,11 +19,13 @@ namespace Timinute.Server.Controllers
         private readonly IRepository<Tag> tagRepository;
         private readonly IMapper mapper;
         private readonly ILogger<TagController> logger;
+        private readonly ApplicationDbContext dbContext;
 
-        public TagController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TagController> logger)
+        public TagController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TagController> logger, ApplicationDbContext dbContext)
         {
             this.mapper = mapper;
             this.logger = logger;
+            this.dbContext = dbContext;
             tagRepository = repositoryFactory.GetRepository<Tag>();
         }
 
@@ -37,17 +40,18 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            var tags = await tagRepository.Get(
-                t => t.UserId == userId,
-                orderBy: query => query.OrderBy(t => t.Name),
-                includeProperties: nameof(Tag.TrackedTasks));
-
-            var dtos = tags.Select(tag =>
-            {
-                var dto = mapper.Map<TagDto>(tag);
-                dto.TaskCount = tag.TrackedTasks?.Count ?? 0;
-                return dto;
-            });
+            var dtos = await dbContext.Tags
+                .AsNoTracking()
+                .Where(t => t.UserId == userId)
+                .OrderBy(t => t.Name)
+                .Select(t => new TagDto
+                {
+                    TagId = t.TagId,
+                    Name = t.Name,
+                    Color = t.Color,
+                    TaskCount = t.TrackedTasks.Count()
+                })
+                .ToListAsync();
 
             return Ok(dtos);
         }
@@ -63,15 +67,24 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            var tag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
+            var tag = await dbContext.Tags
+                .AsNoTracking()
+                .Where(t => t.TagId == id && t.UserId == userId)
+                .Select(t => new TagDto
+                {
+                    TagId = t.TagId,
+                    Name = t.Name,
+                    Color = t.Color,
+                    TaskCount = t.TrackedTasks.Count()
+                })
+                .SingleOrDefaultAsync();
+
             if (tag == null)
             {
                 return NotFound("Tag not found!");
             }
 
-            var dto = mapper.Map<TagDto>(tag);
-            dto.TaskCount = tag.TrackedTasks?.Count ?? 0;
-            return Ok(dto);
+            return Ok(tag);
         }
 
         // CREATE: api/Tag
@@ -153,10 +166,24 @@ namespace Timinute.Server.Controllers
                 return Conflict(new { message = "A tag with this name already exists." });
             }
 
-            var updatedTag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
-            var dto = mapper.Map<TagDto>(updatedTag!);
-            dto.TaskCount = updatedTag?.TrackedTasks?.Count ?? 0;
-            return Ok(dto);
+            var updatedTag = await dbContext.Tags
+                .AsNoTracking()
+                .Where(t => t.TagId == id && t.UserId == userId)
+                .Select(t => new TagDto
+                {
+                    TagId = t.TagId,
+                    Name = t.Name,
+                    Color = t.Color,
+                    TaskCount = t.TrackedTasks.Count()
+                })
+                .SingleOrDefaultAsync();
+
+            if (updatedTag == null)
+            {
+                return NotFound("Tag not found!");
+            }
+
+            return Ok(updatedTag);
         }
 
         // DELETE: api/Tag/{id}
@@ -170,9 +197,7 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            Tag? tag = force
-                ? await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId)
-                : await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
+            var tag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId);
 
             if (tag == null)
             {
@@ -181,7 +206,10 @@ namespace Timinute.Server.Controllers
 
             if (!force)
             {
-                var taskCount = tag.TrackedTasks?.Count ?? 0;
+                var taskCount = await dbContext.TrackedTasks
+                    .IgnoreQueryFilters()
+                    .Where(t => t.UserId == userId && t.Tags.Any(tagRef => tagRef.TagId == id))
+                    .CountAsync();
                 return Ok(new { taskCount });
             }
 

--- a/Timinute/Server/Controllers/TagController.cs
+++ b/Timinute/Server/Controllers/TagController.cs
@@ -1,0 +1,200 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using Timinute.Server.Helpers;
+using Timinute.Server.Models;
+using Timinute.Server.Repository;
+using Timinute.Shared.Dtos.Tag;
+
+namespace Timinute.Server.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class TagController : ControllerBase
+    {
+        private readonly IRepository<Tag> tagRepository;
+        private readonly IMapper mapper;
+        private readonly ILogger<TagController> logger;
+
+        public TagController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TagController> logger)
+        {
+            this.mapper = mapper;
+            this.logger = logger;
+            tagRepository = repositoryFactory.GetRepository<Tag>();
+        }
+
+        // GET: api/Tag
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<TagDto>>> GetTags()
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var tags = await tagRepository.Get(
+                t => t.UserId == userId,
+                orderBy: query => query.OrderBy(t => t.Name),
+                includeProperties: nameof(Tag.TrackedTasks));
+
+            var dtos = tags.Select(tag =>
+            {
+                var dto = mapper.Map<TagDto>(tag);
+                dto.TaskCount = tag.TrackedTasks?.Count ?? 0;
+                return dto;
+            });
+
+            return Ok(dtos);
+        }
+
+        // GET: api/Tag/{id}
+        [HttpGet("{id}")]
+        public async Task<ActionResult<TagDto>> GetTag(string id)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var tag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
+            if (tag == null)
+            {
+                return NotFound("Tag not found!");
+            }
+
+            var dto = mapper.Map<TagDto>(tag);
+            dto.TaskCount = tag.TrackedTasks?.Count ?? 0;
+            return Ok(dto);
+        }
+
+        // CREATE: api/Tag
+        [HttpPost]
+        public async Task<ActionResult<TagDto>> CreateTag([FromBody] CreateTagDto tag)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            if (await tagRepository.CountAsync(t => t.UserId == userId && t.Name == tag.Name) > 0)
+            {
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            var newTag = new Tag
+            {
+                Name = tag.Name,
+                Color = tag.Color,
+                UserId = userId
+            };
+
+            try
+            {
+                await tagRepository.Insert(newTag);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                logger.LogWarning(ex, "Duplicate tag name detected for user {UserId}.", userId);
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            var dto = mapper.Map<TagDto>(newTag);
+            dto.TaskCount = 0;
+            return Ok(dto);
+        }
+
+        // UPDATE: api/Tag
+        [HttpPut("{id}")]
+        public async Task<ActionResult<TagDto>> UpdateTag(string id, [FromBody] UpdateTagDto tag)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            if (id != tag.TagId)
+            {
+                return BadRequest("Route id does not match tag id.");
+            }
+
+            var existingTag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId);
+
+            if (existingTag == null)
+            {
+                return NotFound("Tag not found!");
+            }
+
+            if (await tagRepository.CountAsync(t => t.UserId == userId && t.Name == tag.Name && t.TagId != tag.TagId) > 0)
+            {
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            existingTag.Name = tag.Name;
+            existingTag.Color = tag.Color;
+
+            try
+            {
+                await tagRepository.Update(existingTag);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                logger.LogWarning(ex, "Duplicate tag name detected for user {UserId}.", userId);
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            var updatedTag = await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
+            var dto = mapper.Map<TagDto>(updatedTag!);
+            dto.TaskCount = updatedTag?.TrackedTasks?.Count ?? 0;
+            return Ok(dto);
+        }
+
+        // DELETE: api/Tag/{id}
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteTag(string id, [FromQuery] bool force = false)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            Tag? tag = force
+                ? await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId)
+                : await tagRepository.GetByIdInclude(t => t.TagId == id && t.UserId == userId, includeProperties: nameof(Tag.TrackedTasks));
+
+            if (tag == null)
+            {
+                return NotFound("Tag not found!");
+            }
+
+            if (!force)
+            {
+                var taskCount = tag.TrackedTasks?.Count ?? 0;
+                return Ok(new { taskCount });
+            }
+
+            await tagRepository.Delete(tag);
+            return NoContent();
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            var message = ex.InnerException?.Message ?? ex.Message;
+            return message.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -303,9 +303,20 @@ namespace Timinute.Server.Controllers
             }
 
             await dbContext.SaveChangesAsync();
-            dbContext.Entry(updatedTrackedTask).State = EntityState.Detached;
+            var updatedTrackedTaskEntity = await dbContext.TrackedTasks
+                .AsNoTracking()
+                .Include(t => t.Project)
+                .Include(t => t.Tags)
+                .Where(t => t.TaskId == updatedTrackedTask.TaskId && t.UserId == userId)
+                .SingleOrDefaultAsync();
 
-            return Ok(mapper.Map<TrackedTaskDto>(updatedTrackedTask));
+            if (updatedTrackedTaskEntity == null)
+            {
+                logger.LogError("Tracked task was not found after update");
+                return NotFound("Tracked task not found!");
+            }
+
+            return Ok(mapper.Map<TrackedTaskDto>(updatedTrackedTaskEntity));
         }
 
         private async Task<List<Tag>> ResolveTagsAsync(string userId, IEnumerable<string>? tagIds)

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -1,8 +1,12 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
+using Timinute.Server.Data;
 using Timinute.Server.Helpers;
 using Timinute.Server.Models;
 using Timinute.Server.Models.Paging;
@@ -23,12 +27,14 @@ namespace Timinute.Server.Controllers
         private readonly IMapper mapper;
         private readonly ILogger<TrackedTaskController> logger;
         private readonly IConfiguration configuration;
+        private readonly ApplicationDbContext dbContext;
 
-        public TrackedTaskController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TrackedTaskController> logger, IConfiguration configuration)
+        public TrackedTaskController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TrackedTaskController> logger, IConfiguration configuration, ApplicationDbContext dbContext)
         {
             this.mapper = mapper;
             this.logger = logger;
             this.configuration = configuration;
+            this.dbContext = dbContext;
 
             taskRepository = repositoryFactory.GetRepository<TrackedTask>();
         }
@@ -48,7 +54,7 @@ namespace Timinute.Server.Controllers
             var pagedTrackedTaskList = await taskRepository.GetPaged(trackedTaskParameters,
                 trackedTask => trackedTask.UserId == userId,
                 orderBy: $"{nameof(TrackedTask.StartDate)} desc",
-                includeProperties: "Project");
+                includeProperties: $"{nameof(TrackedTask.Project)},{nameof(TrackedTask.Tags)}");
 
             var metadata = new PaginationHeaderDto
             {
@@ -71,7 +77,8 @@ namespace Timinute.Server.Controllers
             [FromQuery] DateTimeOffset? from = null,
             [FromQuery] DateTimeOffset? to = null,
             [FromQuery] string? projectId = null,
-            [FromQuery] string? search = null)
+            [FromQuery] string? search = null,
+            [FromQuery] List<string>? tagIds = null)
         {
             var userId = User.FindFirstValue(Constants.Claims.UserId);
 
@@ -82,15 +89,17 @@ namespace Timinute.Server.Controllers
 
             var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
             var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId.Trim();
+            var normalizedTagIds = NormalizeTagIds(tagIds);
 
             var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
                 t => t.UserId == userId
                     && (from == null || t.StartDate >= from.Value.ToUniversalTime())
                     && (to == null || t.StartDate <= to.Value.ToUniversalTime())
                     && (normalizedProjectId == null || t.ProjectId == normalizedProjectId)
-                    && (normalizedSearch == null || t.Name.Contains(normalizedSearch)),
+                    && (normalizedSearch == null || t.Name.Contains(normalizedSearch))
+                    && (normalizedTagIds == null || t.Tags.Any(tag => normalizedTagIds.Contains(tag.TagId))),
                 orderBy: $"{nameof(TrackedTask.StartDate)} desc",
-                includeProperties: "Project");
+                includeProperties: $"{nameof(TrackedTask.Project)},{nameof(TrackedTask.Tags)}");
 
             var metadata = new PaginationHeaderDto
             {
@@ -117,8 +126,10 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            var trackedTask = await taskRepository.GetById(id);
-            if (trackedTask == null || trackedTask.UserId != userId)
+            var trackedTask = await taskRepository.GetByIdInclude(
+                t => t.TaskId == id && t.UserId == userId,
+                includeProperties: $"{nameof(TrackedTask.Project)},{nameof(TrackedTask.Tags)}");
+            if (trackedTask == null)
             {
                 return NotFound("Tracked task not found!");
             }
@@ -140,6 +151,7 @@ namespace Timinute.Server.Controllers
             newTrackedTask.UserId = userId;
             newTrackedTask.StartDate = trackedTask.StartDate.ToUniversalTime();
             newTrackedTask.EndDate = newTrackedTask.StartDate + newTrackedTask.Duration;
+            newTrackedTask.Tags = await ResolveTagsAsync(userId, trackedTask.TagIds);
 
             await taskRepository.Insert(newTrackedTask);
             return Ok(mapper.Map<TrackedTaskDto>(newTrackedTask));
@@ -156,15 +168,10 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            var trackedTaskToDelete = await taskRepository.Find(id);
+            var trackedTaskToDelete = await taskRepository.GetByIdInclude(t => t.TaskId == id && t.UserId == userId);
             if (trackedTaskToDelete == null)
             {
                 logger.LogError("Tracked task was not found");
-                return NotFound("Tracked task not found!");
-            }
-
-            if (trackedTaskToDelete.UserId != userId)
-            {
                 return NotFound("Tracked task not found!");
             }
 
@@ -259,16 +266,14 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
-            var foundTrackedTask = await taskRepository.Find(trackedTask.TaskId);
+            var foundTrackedTask = await dbContext.TrackedTasks
+                .Include(t => t.Tags)
+                .AsTracking()
+                .FirstOrDefaultAsync(t => t.TaskId == trackedTask.TaskId && t.UserId == userId);
 
             if (foundTrackedTask == null)
             {
                 logger.LogError("Tracked task was not found");
-                return NotFound("Tracked task not found!");
-            }
-
-            if (foundTrackedTask.UserId != userId)
-            {
                 return NotFound("Tracked task not found!");
             }
 
@@ -287,9 +292,50 @@ namespace Timinute.Server.Controllers
                 updatedTrackedTask.Duration = updatedTrackedTask.EndDate.Value - updatedTrackedTask.StartDate;
             }
 
-            await taskRepository.Update(updatedTrackedTask);
+            if (trackedTask.TagIds != null)
+            {
+                var resolvedTags = await ResolveTagsAsync(userId, trackedTask.TagIds);
+                updatedTrackedTask.Tags.Clear();
+                foreach (var tag in resolvedTags)
+                {
+                    updatedTrackedTask.Tags.Add(tag);
+                }
+            }
+
+            await dbContext.SaveChangesAsync();
+            dbContext.Entry(updatedTrackedTask).State = EntityState.Detached;
 
             return Ok(mapper.Map<TrackedTaskDto>(updatedTrackedTask));
+        }
+
+        private async Task<List<Tag>> ResolveTagsAsync(string userId, IEnumerable<string>? tagIds)
+        {
+            var normalizedTagIds = NormalizeTagIds(tagIds);
+            if (normalizedTagIds == null)
+            {
+                return new List<Tag>();
+            }
+
+            return await dbContext.Tags
+                .AsTracking()
+                .Where(tag => tag.UserId == userId && normalizedTagIds.Contains(tag.TagId))
+                .ToListAsync();
+        }
+
+        private static List<string>? NormalizeTagIds(IEnumerable<string>? tagIds)
+        {
+            if (tagIds == null)
+            {
+                return null;
+            }
+
+            var normalized = tagIds
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct()
+                .ToList();
+
+            return normalized.Count == 0 ? null : normalized;
         }
     }
 }

--- a/Timinute/Server/Data/ApplicationDbContext.cs
+++ b/Timinute/Server/Data/ApplicationDbContext.cs
@@ -17,6 +17,7 @@ namespace Timinute.Server.Data
 
         public DbSet<TrackedTask> TrackedTasks { get; set; } = null!;
         public DbSet<Project> Projects { get; set; } = null!;
+        public DbSet<Tag> Tags { get; set; } = null!;
 
         public ApplicationDbContext(DbContextOptions options) : base(options)
         {
@@ -58,10 +59,23 @@ namespace Timinute.Server.Data
             builder.Entity<Project>().HasKey(t => t.ProjectId);
 
             builder.Entity<Project>()
+                .Property(x => x.Name)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Entity<Project>()
                 .HasQueryFilter(p => p.DeletedAt == null);
 
             builder.Entity<Project>()
                 .HasIndex(p => p.DeletedAt);
+
+            builder.Entity<Project>()
+                .HasIndex(p => p.UserId);
+
+            builder.Entity<Project>()
+                .HasIndex(p => new { p.UserId, p.Name })
+                .HasFilter("[DeletedAt] IS NULL")
+                .IsUnique();
 
             builder.Entity<TrackedTask>()
                 .Property(x => x.TaskId)
@@ -88,6 +102,15 @@ namespace Timinute.Server.Data
             builder.Entity<TrackedTask>()
                 .HasIndex(t => t.DeletedAt);
 
+            builder.Entity<TrackedTask>()
+                .HasIndex(t => t.UserId);
+
+            builder.Entity<TrackedTask>()
+                .HasIndex(t => t.ProjectId);
+
+            builder.Entity<TrackedTask>()
+                .HasIndex(t => new { t.UserId, t.StartDate });
+
             // Setup relationship
 
             builder.Entity<TrackedTask>()
@@ -106,6 +129,32 @@ namespace Timinute.Server.Data
                 .WithMany(u => u.Projects)
                 .HasForeignKey(p => p.UserId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            // Tag entity
+            builder.Entity<Tag>().HasKey(t => t.TagId);
+            builder.Entity<Tag>()
+                .Property(t => t.TagId).ValueGeneratedOnAdd().IsRequired();
+            builder.Entity<Tag>()
+                .Property(t => t.Name).HasMaxLength(30).IsRequired();
+            builder.Entity<Tag>()
+                .Property(t => t.Color).HasMaxLength(7).IsRequired();
+            builder.Entity<Tag>()
+                .HasIndex(t => new { t.UserId, t.Name }).IsUnique();
+            builder.Entity<Tag>()
+                .HasOne(t => t.User)
+                .WithMany(u => u.Tags)
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Many-to-many: TrackedTask <-> Tag via implicit TaskTag join table
+            builder.Entity<TrackedTask>()
+                .HasMany(t => t.Tags)
+                .WithMany(tag => tag.TrackedTasks)
+                .UsingEntity("TaskTag",
+                    l => l.HasOne(typeof(Tag)).WithMany()
+                           .HasForeignKey("TagId").OnDelete(DeleteBehavior.Cascade),
+                    r => r.HasOne(typeof(TrackedTask)).WithMany()
+                           .HasForeignKey("TaskId").OnDelete(DeleteBehavior.Cascade));
 
             FillDataToDB(builder);
         }

--- a/Timinute/Server/Data/Migrations/20260602221538_v2_2_Tags_TechDebt.Designer.cs
+++ b/Timinute/Server/Data/Migrations/20260602221538_v2_2_Tags_TechDebt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Timinute.Server.Data;
 
@@ -11,9 +12,11 @@ using Timinute.Server.Data;
 namespace Timinute.Server.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602221538_v2_2_Tags_TechDebt")]
+    partial class v2_2_Tags_TechDebt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Timinute/Server/Data/Migrations/20260602221538_v2_2_Tags_TechDebt.cs
+++ b/Timinute/Server/Data/Migrations/20260602221538_v2_2_Tags_TechDebt.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Timinute.Server.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class v2_2_Tags_TechDebt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Projects",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateTable(
+                name: "Tags",
+                columns: table => new
+                {
+                    TagId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    Color = table.Column<string>(type: "nvarchar(7)", maxLength: 7, nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tags", x => x.TagId);
+                    table.ForeignKey(
+                        name: "FK_Tags_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TaskTag",
+                columns: table => new
+                {
+                    TagId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TaskId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaskTag", x => new { x.TagId, x.TaskId });
+                    table.ForeignKey(
+                        name: "FK_TaskTag_Tags_TagId",
+                        column: x => x.TagId,
+                        principalTable: "Tags",
+                        principalColumn: "TagId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TaskTag_TrackedTasks_TaskId",
+                        column: x => x.TaskId,
+                        principalTable: "TrackedTasks",
+                        principalColumn: "TaskId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrackedTasks_UserId_StartDate",
+                table: "TrackedTasks",
+                columns: new[] { "UserId", "StartDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_UserId_Name",
+                table: "Projects",
+                columns: new[] { "UserId", "Name" },
+                unique: true,
+                filter: "[DeletedAt] IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tags_UserId_Name",
+                table: "Tags",
+                columns: new[] { "UserId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskTag_TaskId",
+                table: "TaskTag",
+                column: "TaskId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TaskTag");
+
+            migrationBuilder.DropTable(
+                name: "Tags");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TrackedTasks_UserId_StartDate",
+                table: "TrackedTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_UserId_Name",
+                table: "Projects");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Projects",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+        }
+    }
+}

--- a/Timinute/Server/MappingProfile.cs
+++ b/Timinute/Server/MappingProfile.cs
@@ -2,6 +2,7 @@
 using Timinute.Server.Models;
 using Timinute.Shared.Dtos;
 using Timinute.Shared.Dtos.Project;
+using Timinute.Shared.Dtos.Tag;
 using Timinute.Shared.Dtos.TrackedTask;
 
 namespace Timinute.Server
@@ -32,6 +33,13 @@ namespace Timinute.Server
                 // Don't blank out a saved Color when an update arrives without one.
                 // A future "edit name only" flow shouldn't wipe the color picker choice.
                 .ForMember(d => d.Color, o => o.Condition(src => !string.IsNullOrWhiteSpace(src.Color)));
+
+            // Tag model
+            CreateMap<Tag, TagDto>()
+                .ForMember(d => d.TaskCount, o => o.Ignore());
+            CreateMap<TagDto, Tag>()
+                .ForMember(d => d.User, o => o.Ignore())
+                .ForMember(d => d.TrackedTasks, o => o.Ignore());
 
             // Application User model
             CreateMap<ApplicationUser, ApplicationUserDto>();

--- a/Timinute/Server/Models/ApplicationUser.cs
+++ b/Timinute/Server/Models/ApplicationUser.cs
@@ -22,5 +22,7 @@ namespace Timinute.Server.Models
         public ICollection<TrackedTask>? TrackedTasks { get; set; }
 
         public ICollection<Project>? Projects { get; set; }
+
+        public ICollection<Tag>? Tags { get; set; }
     }
 }

--- a/Timinute/Server/Models/Tag.cs
+++ b/Timinute/Server/Models/Tag.cs
@@ -1,0 +1,12 @@
+namespace Timinute.Server.Models
+{
+    public class Tag
+    {
+        public string TagId { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+        public string UserId { get; set; } = null!;
+        public ApplicationUser User { get; set; } = null!;
+        public ICollection<TrackedTask> TrackedTasks { get; set; } = new List<TrackedTask>();
+    }
+}

--- a/Timinute/Server/Models/TrackedTask.cs
+++ b/Timinute/Server/Models/TrackedTask.cs
@@ -9,6 +9,7 @@
         public DateTimeOffset? EndDate { get; set; }
         public string? ProjectId { get; set; }
         public Project? Project { get; set; }
+        public ICollection<Tag> Tags { get; set; } = new List<Tag>();
         public string UserId { get; set; } = null!;
         public ApplicationUser User { get; set; } = null!;
         public DateTimeOffset? DeletedAt { get; set; }

--- a/Timinute/Shared/Dtos/Tag/CreateTagDto.cs
+++ b/Timinute/Shared/Dtos/Tag/CreateTagDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class CreateTagDto
+    {
+        [Required]
+        [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        public string Name { get; set; } = null!;
+
+        [Required]
+        [RegularExpression("^#[0-9A-Fa-f]{6}$", ErrorMessage = "Color must be a valid hex color (e.g. #6366F1).")]
+        public string Color { get; set; } = null!;
+    }
+}

--- a/Timinute/Shared/Dtos/Tag/CreateTagDto.cs
+++ b/Timinute/Shared/Dtos/Tag/CreateTagDto.cs
@@ -6,6 +6,7 @@ namespace Timinute.Shared.Dtos.Tag
     {
         [Required]
         [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        [RegularExpression("^.*\\S.*$", ErrorMessage = "Tag name must contain at least one non-whitespace character.")]
         public string Name { get; set; } = null!;
 
         [Required]

--- a/Timinute/Shared/Dtos/Tag/TagDto.cs
+++ b/Timinute/Shared/Dtos/Tag/TagDto.cs
@@ -1,0 +1,10 @@
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class TagDto
+    {
+        public string TagId { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+        public int TaskCount { get; set; }
+    }
+}

--- a/Timinute/Shared/Dtos/Tag/UpdateTagDto.cs
+++ b/Timinute/Shared/Dtos/Tag/UpdateTagDto.cs
@@ -9,6 +9,7 @@ namespace Timinute.Shared.Dtos.Tag
 
         [Required]
         [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        [RegularExpression("^.*\\S.*$", ErrorMessage = "Tag name must contain at least one non-whitespace character.")]
         public string Name { get; set; } = null!;
 
         [Required]

--- a/Timinute/Shared/Dtos/Tag/UpdateTagDto.cs
+++ b/Timinute/Shared/Dtos/Tag/UpdateTagDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class UpdateTagDto
+    {
+        [Required]
+        public string TagId { get; set; } = null!;
+
+        [Required]
+        [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        public string Name { get; set; } = null!;
+
+        [Required]
+        [RegularExpression("^#[0-9A-Fa-f]{6}$", ErrorMessage = "Color must be a valid hex color (e.g. #6366F1).")]
+        public string Color { get; set; } = null!;
+    }
+}

--- a/Timinute/Shared/Dtos/TrackedTask/CreateTrackedTaskDto.cs
+++ b/Timinute/Shared/Dtos/TrackedTask/CreateTrackedTaskDto.cs
@@ -21,5 +21,6 @@ namespace Timinute.Shared.Dtos.TrackedTask
         public string? ProjectId { get; set; }
 
         public ProjectDto? Project { get; set; }
+        public List<string> TagIds { get; set; } = new();
     }
 }

--- a/Timinute/Shared/Dtos/TrackedTask/TrackedTaskDto.cs
+++ b/Timinute/Shared/Dtos/TrackedTask/TrackedTaskDto.cs
@@ -1,4 +1,5 @@
 ﻿using Timinute.Shared.Dtos.Project;
+using Timinute.Shared.Dtos.Tag;
 
 namespace Timinute.Shared.Dtos.TrackedTask
 {
@@ -11,6 +12,7 @@ namespace Timinute.Shared.Dtos.TrackedTask
         public DateTimeOffset? EndDate { get; set; }
         public string? ProjectId { get; set; }
         public ProjectDto? Project { get; set; }
+        public List<TagDto> Tags { get; set; } = new();
         public string UserId { get; set; } = null!;
         public ApplicationUserDto User { get; set; } = null!;
     }

--- a/Timinute/Shared/Dtos/TrackedTask/UpdateTrackedTaskDto.cs
+++ b/Timinute/Shared/Dtos/TrackedTask/UpdateTrackedTaskDto.cs
@@ -22,5 +22,6 @@ namespace Timinute.Shared.Dtos.TrackedTask
         public string? ProjectId { get; set; }
 
         public ProjectDto? Project { get; set; }
+        public List<string>? TagIds { get; set; }
     }
 }

--- a/docs/superpowers/plans/2026-06-02-v2.2-tags-techdebt.md
+++ b/docs/superpowers/plans/2026-06-02-v2.2-tags-techdebt.md
@@ -1,0 +1,2608 @@
+# v2.2 Tags / Labels + Tech-Debt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user-scoped Tags/Labels to tracked tasks with full CRUD management, inline assignment in task modals, tag-based filtering, plus DB performance indexes and unique project name constraint.
+
+**Architecture:** New `Tag` entity with EF Core implicit many-to-many to `TrackedTask` via `TaskTag` join table; `TagController` mirrors the `ProjectController` pattern; `TrackedTaskController` receives `ApplicationDbContext` as a 5th constructor parameter alongside its repositories to handle M2M tag sync (EF Core requires a tracked context to clear-and-replace a collection on a NoTracking entity); client TagPicker component and a standalone Tags management page at `/tags`.
+
+**Tech Stack:** .NET 10, EF Core (SQL Server in prod / InMemory+SQLite in tests), AutoMapper, Blazor WASM, xUnit, Moq; bUnit added to Client.Tests for TagPicker component tests.
+
+---
+
+## File Map
+
+**Create:**
+- `Timinute/Server/Models/Tag.cs`
+- `Timinute/Shared/Dtos/Tag/TagDto.cs`
+- `Timinute/Shared/Dtos/Tag/CreateTagDto.cs`
+- `Timinute/Shared/Dtos/Tag/UpdateTagDto.cs`
+- `Timinute/Server/Controllers/TagController.cs`
+- `Timinute/Server.Tests/Controllers/TagControllerTest.cs`
+- `Timinute/Client/Pages/Tags/Tags.razor`
+- `Timinute/Client/Pages/Tags/Tags.razor.css`
+- `Timinute/Client/Components/TagPicker.razor`
+- `Timinute/Client/Components/TagPicker.razor.css`
+- `Timinute/Client.Tests/Components/TagPickerTest.cs`
+
+**Modify:**
+- `Timinute/Server/Models/ApplicationUser.cs` — add Tags nav property
+- `Timinute/Server/Models/TrackedTask.cs` — add Tags nav property
+- `Timinute/Server/Data/ApplicationDbContext.cs` — add DbSet\<Tag\>, EF config, M2M, indexes
+- `Timinute/Server/MappingProfile.cs` — add Tag↔TagDto mapping
+- `Timinute/Shared/Dtos/TrackedTask/TrackedTaskDto.cs` — add Tags list
+- `Timinute/Shared/Dtos/TrackedTask/CreateTrackedTaskDto.cs` — add TagIds
+- `Timinute/Shared/Dtos/TrackedTask/UpdateTrackedTaskDto.cs` — add TagIds
+- `Timinute/Server/Controllers/ProjectController.cs` — 409 on duplicate name
+- `Timinute/Server/Controllers/TrackedTaskController.cs` — inject dbContext, add tag includes/filter/sync
+- `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs` — update CreateController + tag tests
+- `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs` — add 409 duplicate-name tests
+- `Timinute/Client/Helpers/Constants.cs` — add API.Tag constants
+- `Timinute/Client/Shared/NavMenu.razor` — add Tags nav item
+- `Timinute/Client/Shared/AuroraIcons.razor` — add "tag" icon case
+- `Timinute/Client/Models/TrackedTask.cs` — add Tags + TagIds
+- `Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor` — tag filter chips, pass TagIds on update
+- `Timinute/Client/Components/Scheduler/EditTrackedTaskForm.razor` — add TagPicker
+- `Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor` — add TagPicker markup
+- `Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor.cs` — add TagIds field
+- `Timinute/Client.Tests/Timinute.Client.Tests.csproj` — add bUnit, change SDK to Razor
+
+---
+
+### Task 1: DB Indexes + Project Unique Constraint
+
+**Files:**
+- Modify: `Timinute/Server/Data/ApplicationDbContext.cs`
+
+- [ ] **Step 1: Add index config inside OnModelCreating**
+
+In `ApplicationDbContext.cs`, inside `OnModelCreating`, after the existing `Project` entity config (before the `FillDataToDB(builder);` call), add:
+
+```csharp
+// Tech-debt: performance indexes
+builder.Entity<TrackedTask>().HasIndex(t => t.UserId);
+builder.Entity<TrackedTask>().HasIndex(t => t.ProjectId);
+builder.Entity<TrackedTask>().HasIndex(t => new { t.UserId, t.StartDate });
+builder.Entity<Project>().HasIndex(p => p.UserId);
+
+// Unique project name per user; soft-deleted names can be reused
+builder.Entity<Project>()
+    .HasIndex(p => new { p.UserId, p.Name })
+    .IsUnique()
+    .HasFilter("[DeletedAt] IS NULL");
+```
+
+- [ ] **Step 2: Build the Server project**
+
+```
+dotnet build Timinute\Server\Timinute.Server.csproj
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Timinute/Server/Data/ApplicationDbContext.cs
+git commit -m "chore: add DB indexes and filtered unique constraint on Project(UserId,Name)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: Tag Model + Nav Properties + DbContext Config
+
+**Files:**
+- Create: `Timinute/Server/Models/Tag.cs`
+- Modify: `Timinute/Server/Models/ApplicationUser.cs`
+- Modify: `Timinute/Server/Models/TrackedTask.cs`
+- Modify: `Timinute/Server/Data/ApplicationDbContext.cs`
+
+- [ ] **Step 1: Create Tag.cs**
+
+Create `Timinute/Server/Models/Tag.cs`:
+
+```csharp
+namespace Timinute.Server.Models
+{
+    public class Tag
+    {
+        public string TagId { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+        public string UserId { get; set; } = null!;
+        public ApplicationUser User { get; set; } = null!;
+        public ICollection<TrackedTask> TrackedTasks { get; set; } = new List<TrackedTask>();
+    }
+}
+```
+
+- [ ] **Step 2: Add Tags nav property to ApplicationUser**
+
+In `Timinute/Server/Models/ApplicationUser.cs`, add after the `Projects` property:
+
+```csharp
+public ICollection<Tag>? Tags { get; set; }
+```
+
+- [ ] **Step 3: Add Tags nav property to TrackedTask**
+
+In `Timinute/Server/Models/TrackedTask.cs`, add after the existing nav properties (e.g., after `Project`):
+
+```csharp
+public ICollection<Tag> Tags { get; set; } = new List<Tag>();
+```
+
+- [ ] **Step 4: Add DbSet and EF config to ApplicationDbContext**
+
+In `ApplicationDbContext.cs`:
+
+**4a.** Add after `public DbSet<Project> Projects { get; set; } = null!;`:
+```csharp
+public DbSet<Tag> Tags { get; set; } = null!;
+```
+
+**4b.** Inside `OnModelCreating`, after the tech-debt indexes added in Task 1 (before `FillDataToDB(builder);`), add:
+
+```csharp
+// Tag entity
+builder.Entity<Tag>().HasKey(t => t.TagId);
+builder.Entity<Tag>()
+    .Property(t => t.TagId).ValueGeneratedOnAdd().IsRequired();
+builder.Entity<Tag>()
+    .Property(t => t.Name).HasMaxLength(30).IsRequired();
+builder.Entity<Tag>()
+    .Property(t => t.Color).HasMaxLength(7).IsRequired();
+builder.Entity<Tag>()
+    .HasIndex(t => new { t.UserId, t.Name }).IsUnique();
+builder.Entity<Tag>()
+    .HasOne(t => t.User)
+    .WithMany(u => u.Tags)
+    .HasForeignKey(t => t.UserId)
+    .OnDelete(DeleteBehavior.Cascade);
+
+// Many-to-many: TrackedTask <-> Tag via implicit TaskTag join table
+builder.Entity<TrackedTask>()
+    .HasMany(t => t.Tags)
+    .WithMany(tag => tag.TrackedTasks)
+    .UsingEntity("TaskTag",
+        l => l.HasOne(typeof(Tag)).WithMany()
+               .HasForeignKey("TagId").OnDelete(DeleteBehavior.Cascade),
+        r => r.HasOne(typeof(TrackedTask)).WithMany()
+               .HasForeignKey("TaskId").OnDelete(DeleteBehavior.Cascade));
+```
+
+- [ ] **Step 5: Build to verify no errors**
+
+```
+dotnet build Timinute\Server\Timinute.Server.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Models/Tag.cs Timinute/Server/Models/ApplicationUser.cs Timinute/Server/Models/TrackedTask.cs Timinute/Server/Data/ApplicationDbContext.cs
+git commit -m "feat: add Tag entity with M2M relationship to TrackedTask
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: EF Migration
+
+**Files:**
+- Create: `Timinute/Server/Migrations/` (auto-generated)
+
+- [ ] **Step 1: Generate migration from solution root**
+
+```
+dotnet ef migrations add v2_2_Tags_TechDebt --project Timinute\Server\Timinute.Server.csproj --startup-project Timinute\Server\Timinute.Server.csproj
+```
+
+Expected: `Done. To undo this action, use 'ef migrations remove'`
+
+The generated migration must contain:
+- `CreateTable("Tags", ...)` with `TagId` (PK), `Name NVARCHAR(30)`, `Color NVARCHAR(7)`, `UserId` (FK → AspNetUsers)
+- `CreateTable("TaskTag", ...)` with `TagId` (FK → Tags, cascade) and `TaskId` (FK → TrackedTasks, cascade)
+- `CreateIndex("IX_TrackedTasks_UserId", ...)` — non-unique
+- `CreateIndex("IX_TrackedTasks_ProjectId", ...)` — non-unique
+- `CreateIndex("IX_TrackedTasks_UserId_StartDate", ...)` — composite
+- `CreateIndex("IX_Projects_UserId", ...)` — non-unique
+- `CreateIndex("IX_Projects_UserId_Name", ...)` — unique with `filter: "[DeletedAt] IS NULL"`
+- `CreateIndex("IX_Tags_UserId_Name", ...)` — unique (no filter — Tags have no soft delete)
+
+- [ ] **Step 2: Review the generated migration file**
+
+Open the generated `.cs` file in `Timinute/Server/Migrations/`. Verify all tables/indexes above are present and the filter on the project index is `"[DeletedAt] IS NULL"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Timinute/Server/Migrations/
+git commit -m "chore: EF migration v2_2_Tags_TechDebt — Tags table, indexes, unique constraints
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: Tag DTOs + Update TrackedTask DTOs
+
+**Files:**
+- Create: `Timinute/Shared/Dtos/Tag/TagDto.cs`
+- Create: `Timinute/Shared/Dtos/Tag/CreateTagDto.cs`
+- Create: `Timinute/Shared/Dtos/Tag/UpdateTagDto.cs`
+- Modify: `Timinute/Shared/Dtos/TrackedTask/TrackedTaskDto.cs`
+- Modify: `Timinute/Shared/Dtos/TrackedTask/CreateTrackedTaskDto.cs`
+- Modify: `Timinute/Shared/Dtos/TrackedTask/UpdateTrackedTaskDto.cs`
+
+- [ ] **Step 1: Create TagDto.cs**
+
+Create `Timinute/Shared/Dtos/Tag/TagDto.cs`:
+
+```csharp
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class TagDto
+    {
+        public string TagId { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+        public int TaskCount { get; set; }
+    }
+}
+```
+
+- [ ] **Step 2: Create CreateTagDto.cs**
+
+Create `Timinute/Shared/Dtos/Tag/CreateTagDto.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class CreateTagDto
+    {
+        [Required]
+        [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        public string Name { get; set; } = null!;
+
+        [Required]
+        [RegularExpression("^#[0-9A-Fa-f]{6}$", ErrorMessage = "Color must be a valid hex color (e.g. #6366F1).")]
+        public string Color { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 3: Create UpdateTagDto.cs**
+
+Create `Timinute/Shared/Dtos/Tag/UpdateTagDto.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Timinute.Shared.Dtos.Tag
+{
+    public class UpdateTagDto
+    {
+        [Required]
+        public string TagId { get; set; } = null!;
+
+        [Required]
+        [StringLength(30, MinimumLength = 1, ErrorMessage = "Tag name must be between 1 and 30 characters.")]
+        public string Name { get; set; } = null!;
+
+        [Required]
+        [RegularExpression("^#[0-9A-Fa-f]{6}$", ErrorMessage = "Color must be a valid hex color (e.g. #6366F1).")]
+        public string Color { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Update TrackedTaskDto.cs**
+
+Add `using Timinute.Shared.Dtos.Tag;` at the top, then add the property:
+
+```csharp
+public List<TagDto> Tags { get; set; } = new();
+```
+
+- [ ] **Step 5: Update CreateTrackedTaskDto.cs**
+
+Add the property:
+
+```csharp
+public List<string> TagIds { get; set; } = new();
+```
+
+- [ ] **Step 6: Update UpdateTrackedTaskDto.cs**
+
+Add the property:
+
+```csharp
+public List<string> TagIds { get; set; } = new();
+```
+
+- [ ] **Step 7: Build the Shared project**
+
+```
+dotnet build Timinute\Shared\Timinute.Shared.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Timinute/Shared/Dtos/Tag/ Timinute/Shared/Dtos/TrackedTask/
+git commit -m "feat: add Tag DTOs and extend TrackedTask DTOs with TagIds/Tags
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: MappingProfile Update
+
+**Files:**
+- Modify: `Timinute/Server/MappingProfile.cs`
+
+- [ ] **Step 1: Add Tag ↔ TagDto mapping**
+
+In `MappingProfile.cs`, add the `using` at the top:
+
+```csharp
+using Timinute.Shared.Dtos.Tag;
+```
+
+Inside the constructor, after the existing `ApplicationUser` mappings, add:
+
+```csharp
+// Tag model
+CreateMap<Tag, TagDto>()
+    .ForMember(d => d.TaskCount, o => o.Ignore()); // set manually in controller
+
+CreateMap<TagDto, Tag>()
+    .ForMember(d => d.User, o => o.Ignore())
+    .ForMember(d => d.TrackedTasks, o => o.Ignore());
+```
+
+Note: `TaskCount` is computed from `tag.TrackedTasks.Count` in the controller after mapping, because it requires the navigation property to be loaded.
+
+- [ ] **Step 2: Build the Server project**
+
+```
+dotnet build Timinute\Server\Timinute.Server.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Timinute/Server/MappingProfile.cs
+git commit -m "feat: add Tag <-> TagDto AutoMapper mapping
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: TagController (TDD)
+
+**Files:**
+- Create: `Timinute/Server.Tests/Controllers/TagControllerTest.cs`
+- Create: `Timinute/Server/Controllers/TagController.cs`
+
+- [ ] **Step 1: Write failing tests for TagController**
+
+Create `Timinute/Server.Tests/Controllers/TagControllerTest.cs`:
+
+```csharp
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Timinute.Server.Controllers;
+using Timinute.Server.Data;
+using Timinute.Server.Models;
+using Timinute.Server.Repository;
+using Timinute.Server.Tests.Helpers;
+using Timinute.Shared.Dtos.Tag;
+using Xunit;
+
+namespace Timinute.Server.Tests.Controllers
+{
+    public class TagControllerTest : ControllerTestBase<TagController>
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<ILogger<TagController>> _loggerMock;
+        private const string _databaseName = "TagController_Test_DB";
+
+        public TagControllerTest()
+        {
+            var configExpression = new MapperConfigurationExpression();
+            configExpression.AddProfile<MappingProfile>();
+            var configuration = new MapperConfiguration(configExpression,
+                Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
+            _mapper = new Mapper(configuration);
+            _loggerMock = new Mock<ILogger<TagController>>();
+        }
+
+        [Fact]
+        public async Task GetAll_Returns_Only_Owned_Tags_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_GetAll");
+            db.Tags.AddRange(
+                new Tag { Name = "work",  Color = "#6366F1", UserId = "ApplicationUser1" },
+                new Tag { Name = "other", Color = "#F59E0B", UserId = "ApplicationUser2" }
+            );
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.GetTags();
+
+            var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+            var tags = Assert.IsAssignableFrom<IEnumerable<TagDto>>(ok.Value).ToList();
+            Assert.Single(tags);
+            Assert.Equal("work", tags[0].Name);
+        }
+
+        [Fact]
+        public async Task GetAll_Tags_Ordered_By_Name_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_GetAllOrdered");
+            db.Tags.AddRange(
+                new Tag { Name = "zebra", Color = "#6366F1", UserId = "ApplicationUser1" },
+                new Tag { Name = "alpha", Color = "#F59E0B", UserId = "ApplicationUser1" }
+            );
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.GetTags();
+
+            var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+            var tags = Assert.IsAssignableFrom<IEnumerable<TagDto>>(ok.Value).ToList();
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("alpha", tags[0].Name);
+            Assert.Equal("zebra", tags[1].Name);
+        }
+
+        [Fact]
+        public async Task GetTag_Returns_NotFound_For_Wrong_User_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_GetWrongUser");
+            var tag = new Tag { Name = "mine", Color = "#6366F1", UserId = "ApplicationUser2" };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db); // logged in as ApplicationUser1
+            var result = await controller.GetTag(tag.TagId);
+
+            Assert.IsAssignableFrom<NotFoundObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task Create_Tag_Returns_Ok_With_TagDto_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_Create");
+            var controller = await CreateController(db);
+
+            var result = await controller.CreateTag(new CreateTagDto { Name = "feature", Color = "#10B981" });
+
+            var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+            var created = Assert.IsAssignableFrom<TagDto>(ok.Value);
+            Assert.Equal("feature", created.Name);
+            Assert.Equal("#10B981", created.Color);
+            Assert.Equal(0, created.TaskCount);
+        }
+
+        [Fact]
+        public async Task Create_Tag_Persists_To_Database_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_CreatePersists");
+            var controller = await CreateController(db);
+
+            await controller.CreateTag(new CreateTagDto { Name = "saved", Color = "#6366F1" });
+
+            var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == "saved");
+            Assert.NotNull(tag);
+            Assert.Equal("ApplicationUser1", tag!.UserId);
+        }
+
+        [Fact]
+        public async Task Create_Duplicate_Tag_Name_Returns_409_Test()
+        {
+            // Unique constraint enforcement requires SQLite (InMemory ignores unique indexes)
+            using var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+            var db = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+            var controller = await CreateController(db);
+            await controller.CreateTag(new CreateTagDto { Name = "bug", Color = "#EC4899" });
+
+            var result = await controller.CreateTag(new CreateTagDto { Name = "bug", Color = "#F59E0B" });
+
+            Assert.IsAssignableFrom<ConflictObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task Update_Tag_Returns_Updated_Dto_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_Update");
+            var tag = new Tag { Name = "old", Color = "#6366F1", UserId = "ApplicationUser1" };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.UpdateTag(new UpdateTagDto { TagId = tag.TagId, Name = "new", Color = "#F59E0B" });
+
+            var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+            var updated = Assert.IsAssignableFrom<TagDto>(ok.Value);
+            Assert.Equal("new", updated.Name);
+            Assert.Equal("#F59E0B", updated.Color);
+        }
+
+        [Fact]
+        public async Task Update_Tag_Wrong_User_Returns_NotFound_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_UpdateAuth");
+            var tag = new Tag { Name = "theirs", Color = "#6366F1", UserId = "ApplicationUser2" };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db); // logged in as ApplicationUser1
+            var result = await controller.UpdateTag(new UpdateTagDto { TagId = tag.TagId, Name = "hacked", Color = "#000000" });
+
+            Assert.IsAssignableFrom<NotFoundObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task Delete_NoForce_Returns_Task_Count_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_DeleteNoForce");
+            var tag = new Tag { Name = "busy", Color = "#6366F1", UserId = "ApplicationUser1" };
+            var task = await db.TrackedTasks.FirstAsync(t => t.TaskId == "TrackedTaskId1");
+            tag.TrackedTasks.Add(task);
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.DeleteTag(tag.TagId, force: false);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            // Response body is anonymous { taskCount: 1 }
+            var body = ok.Value!;
+            var taskCountProp = body.GetType().GetProperty("taskCount");
+            Assert.NotNull(taskCountProp);
+            Assert.Equal(1, (int)taskCountProp!.GetValue(body)!);
+        }
+
+        [Fact]
+        public async Task Delete_Force_Removes_Tag_And_Preserves_Task_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_DeleteForce");
+            var tag = new Tag { Name = "removeme", Color = "#6366F1", UserId = "ApplicationUser1" };
+            var task = await db.TrackedTasks.FirstAsync(t => t.TaskId == "TrackedTaskId1");
+            tag.TrackedTasks.Add(task);
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            var tagId = tag.TagId;
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.DeleteTag(tagId, force: true);
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.Null(await db.Tags.FirstOrDefaultAsync(t => t.TagId == tagId));
+            Assert.NotNull(await db.TrackedTasks.FirstOrDefaultAsync(t => t.TaskId == "TrackedTaskId1"));
+        }
+
+        [Fact]
+        public async Task Delete_Tag_Wrong_User_Returns_NotFound_Test()
+        {
+            var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_DeleteAuth");
+            var tag = new Tag { Name = "protected", Color = "#6366F1", UserId = "ApplicationUser2" };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var controller = await CreateController(db);
+            var result = await controller.DeleteTag(tag.TagId, force: false);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        protected override async Task<TagController> CreateController(
+            ApplicationDbContext? applicationDbContext = null,
+            string userId = "ApplicationUser1")
+        {
+            if (applicationDbContext == null)
+                applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName);
+
+            var repositoryFactory = new RepositoryFactory(applicationDbContext);
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("sub", userId),
+                new Claim(ClaimTypes.Name, "test@email.com")
+            }));
+
+            return new TagController(repositoryFactory, _mapper, _loggerMock.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = user }
+                }
+            };
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail (TagController doesn't exist yet)**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "FullyQualifiedName~TagControllerTest" -v m
+```
+
+Expected: FAIL with compile errors — `TagController` not found.
+
+- [ ] **Step 3: Implement TagController**
+
+Create `Timinute/Server/Controllers/TagController.cs`:
+
+```csharp
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using Timinute.Server.Helpers;
+using Timinute.Server.Models;
+using Timinute.Server.Repository;
+using Timinute.Shared.Dtos.Tag;
+
+namespace Timinute.Server.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class TagController : ControllerBase
+    {
+        private readonly IRepository<Tag> tagRepository;
+        private readonly IMapper mapper;
+        private readonly ILogger<TagController> logger;
+
+        public TagController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TagController> logger)
+        {
+            this.mapper = mapper;
+            this.logger = logger;
+            tagRepository = repositoryFactory.GetRepository<Tag>();
+        }
+
+        // GET: /Tag
+        [HttpGet(Name = "Tags")]
+        public async Task<ActionResult<IEnumerable<TagDto>>> GetTags()
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var tags = (await tagRepository.Get(
+                t => t.UserId == userId,
+                orderBy: q => q.OrderBy(t => t.Name),
+                includeProperties: "TrackedTasks")).ToList();
+
+            var dtos = tags.Select(t =>
+            {
+                var dto = mapper.Map<TagDto>(t);
+                dto.TaskCount = t.TrackedTasks.Count;
+                return dto;
+            }).ToList();
+
+            return Ok(dtos);
+        }
+
+        // GET: /Tag/{id}
+        [HttpGet("{id}")]
+        public async Task<ActionResult<TagDto>> GetTag(string id)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var tag = await tagRepository.GetByIdInclude(t => t.TagId == id, "TrackedTasks");
+            if (tag == null || tag.UserId != userId) return NotFound("Tag not found!");
+
+            var dto = mapper.Map<TagDto>(tag);
+            dto.TaskCount = tag.TrackedTasks.Count;
+            return Ok(dto);
+        }
+
+        // POST: /Tag
+        [HttpPost]
+        public async Task<ActionResult<TagDto>> CreateTag([FromBody] CreateTagDto createTagDto)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var tag = new Tag
+            {
+                Name = createTagDto.Name,
+                Color = createTagDto.Color,
+                UserId = userId
+            };
+
+            try
+            {
+                await tagRepository.Insert(tag);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            var dto = mapper.Map<TagDto>(tag);
+            dto.TaskCount = 0;
+            return Ok(dto);
+        }
+
+        // PUT: /Tag
+        [HttpPut]
+        public async Task<ActionResult<TagDto>> UpdateTag([FromBody] UpdateTagDto updateTagDto)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var tag = await tagRepository.GetByIdInclude(t => t.TagId == updateTagDto.TagId, "TrackedTasks");
+            if (tag == null || tag.UserId != userId) return NotFound("Tag not found!");
+
+            tag.Name = updateTagDto.Name;
+            tag.Color = updateTagDto.Color;
+
+            try
+            {
+                await tagRepository.Update(tag);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                return Conflict(new { message = "A tag with this name already exists." });
+            }
+
+            var dto = mapper.Map<TagDto>(tag);
+            dto.TaskCount = tag.TrackedTasks.Count;
+            return Ok(dto);
+        }
+
+        // DELETE: /Tag/{id}?force=false
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteTag(string id, [FromQuery] bool force = false)
+        {
+            var userId = User.FindFirstValue(Constants.Claims.UserId);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var tag = await tagRepository.GetByIdInclude(t => t.TagId == id, "TrackedTasks");
+            if (tag == null || tag.UserId != userId) return NotFound("Tag not found!");
+
+            if (!force)
+            {
+                return Ok(new { taskCount = tag.TrackedTasks.Count });
+            }
+
+            await tagRepository.Delete(tag);
+            logger.LogInformation("Tag {TagId} hard-deleted for user {UserId}", id, userId);
+            return NoContent();
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            var msg = ex.InnerException?.Message ?? ex.Message;
+            return msg.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run TagController tests**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "FullyQualifiedName~TagControllerTest" -v m
+```
+
+Expected: All 9 TagControllerTest tests PASS.
+
+- [ ] **Step 5: Run all Server.Tests to confirm no regressions**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj -v m
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Timinute/Server/Controllers/TagController.cs Timinute/Server.Tests/Controllers/TagControllerTest.cs
+git commit -m "feat: TagController with CRUD and force-delete; TagControllerTest
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 7: ProjectController 409 on Duplicate Name (TDD)
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Controllers/ProjectControllerTest.cs`
+- Modify: `Timinute/Server/Controllers/ProjectController.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add `using Microsoft.Data.Sqlite;` at the top of `ProjectControllerTest.cs`.
+
+Add these two tests at the end of the class (before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Create_Project_Duplicate_Name_Returns_409_Test()
+{
+    // Unique constraint enforcement requires SQLite (InMemory ignores it)
+    using var connection = new SqliteConnection("DataSource=:memory:");
+    await connection.OpenAsync();
+    var db = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+    var controller = await CreateController(db);
+    await controller.CreateProject(new CreateProjectDto { Name = "Duplicate" });
+
+    var result = await controller.CreateProject(new CreateProjectDto { Name = "Duplicate" });
+
+    Assert.IsType<ConflictObjectResult>(result.Result);
+}
+
+[Fact]
+public async Task Create_Project_Same_Name_As_Soft_Deleted_Succeeds_Test()
+{
+    // Filtered unique index: soft-deleted names can be reused — SQLite enforces the filter
+    using var connection = new SqliteConnection("DataSource=:memory:");
+    await connection.OpenAsync();
+    var db = await TestHelper.GetSqliteApplicationDbContext(connection);
+
+    var controller = await CreateController(db);
+    var firstResult = await controller.CreateProject(new CreateProjectDto { Name = "Reusable" });
+    var first = ((firstResult.Result as OkObjectResult)!.Value as ProjectDto)!;
+
+    await controller.DeleteProject(first.ProjectId);
+
+    var secondResult = await controller.CreateProject(new CreateProjectDto { Name = "Reusable" });
+    Assert.IsType<OkObjectResult>(secondResult.Result);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "Create_Project_Duplicate_Name_Returns_409" -v m
+```
+
+Expected: FAIL — CreateProject does not yet catch `DbUpdateException`.
+
+- [ ] **Step 3: Add 409 handling to ProjectController**
+
+In `ProjectController.cs`:
+
+**3a.** Add `using Microsoft.EntityFrameworkCore;` at the top if not already present.
+
+**3b.** In `CreateProject`, replace:
+```csharp
+await projectRepository.Insert(newProject);
+return Ok(mapper.Map<ProjectDto>(newProject));
+```
+with:
+```csharp
+try
+{
+    await projectRepository.Insert(newProject);
+}
+catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+{
+    return Conflict(new { message = "A project with this name already exists." });
+}
+return Ok(mapper.Map<ProjectDto>(newProject));
+```
+
+**3c.** In `UpdateProject`, replace:
+```csharp
+await projectRepository.Update(updatedProject);
+return Ok(mapper.Map<ProjectDto>(updatedProject));
+```
+with:
+```csharp
+try
+{
+    await projectRepository.Update(updatedProject);
+}
+catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+{
+    return Conflict(new { message = "A project with this name already exists." });
+}
+return Ok(mapper.Map<ProjectDto>(updatedProject));
+```
+
+**3d.** Add the helper method at the bottom of the `ProjectController` class (before the closing `}`):
+
+```csharp
+private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+{
+    var msg = ex.InnerException?.Message ?? ex.Message;
+    return msg.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase)
+        || msg.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+        || msg.Contains("duplicate key", StringComparison.OrdinalIgnoreCase);
+}
+```
+
+- [ ] **Step 4: Run ProjectController tests**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "FullyQualifiedName~ProjectControllerTest" -v m
+```
+
+Expected: All ProjectControllerTest tests pass, including the 2 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Server/Controllers/ProjectController.cs Timinute/Server.Tests/Controllers/ProjectControllerTest.cs
+git commit -m "feat: return 409 Conflict on duplicate project name per user; add tests
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: TrackedTaskController Tag Support (TDD)
+
+**Files:**
+- Modify: `Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs`
+- Modify: `Timinute/Server/Controllers/TrackedTaskController.cs`
+
+**Design note:** `BaseRepository.Update` calls `dbSet.Update(entity)` which attaches a NoTracking entity as Modified. For implicit M2M collections, EF Core cannot infer which join rows to delete because it has no prior snapshot. Injecting `ApplicationDbContext` directly gives us a tracked context to clear-and-replace `Tags` correctly. The same DbContext instance is used for both the repository (via `RepositoryFactory`) and the direct tag sync.
+
+- [ ] **Step 1: Write failing tests for tag support**
+
+Add these imports to `TrackedTaskControllerTest.cs` if not present:
+```csharp
+using System.Collections.Generic;
+using Timinute.Server.Models;
+```
+
+Add these tests at the end of the class:
+
+```csharp
+[Fact]
+public async Task Create_TrackedTask_With_Tags_Attaches_Tags_Test()
+{
+    var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_CreateWithTags");
+    var tag = new Tag { Name = "work", Color = "#6366F1", UserId = "ApplicationUser1" };
+    db.Tags.Add(tag);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var controller = await CreateController(db);
+    var dto = new CreateTrackedTaskDto
+    {
+        Name = "Tagged Task",
+        StartDate = DateTimeOffset.UtcNow,
+        Duration = TimeSpan.FromHours(1),
+        TagIds = new List<string> { tag.TagId }
+    };
+
+    var result = await controller.CreateTrackedTask(dto);
+
+    var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+    var created = Assert.IsAssignableFrom<TrackedTaskDto>(ok.Value);
+    Assert.Single(created.Tags);
+    Assert.Equal("work", created.Tags[0].Name);
+}
+
+[Fact]
+public async Task Create_TrackedTask_With_Unowned_TagId_Skips_Tag_Test()
+{
+    var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_CreateUnownedTag");
+    var tag = new Tag { Name = "theirs", Color = "#6366F1", UserId = "ApplicationUser2" };
+    db.Tags.Add(tag);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var controller = await CreateController(db); // logged in as ApplicationUser1
+    var dto = new CreateTrackedTaskDto
+    {
+        Name = "No Tags Task",
+        StartDate = DateTimeOffset.UtcNow,
+        Duration = TimeSpan.FromHours(1),
+        TagIds = new List<string> { tag.TagId }
+    };
+
+    var result = await controller.CreateTrackedTask(dto);
+
+    var ok = Assert.IsAssignableFrom<OkObjectResult>(result.Result);
+    var created = Assert.IsAssignableFrom<TrackedTaskDto>(ok.Value);
+    Assert.Empty(created.Tags); // unowned tag silently skipped
+}
+
+[Fact]
+public async Task Update_TrackedTask_Replaces_Tags_Test()
+{
+    var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_UpdateTags");
+    var tagA = new Tag { Name = "alpha", Color = "#6366F1", UserId = "ApplicationUser1" };
+    var tagB = new Tag { Name = "beta",  Color = "#F59E0B", UserId = "ApplicationUser1" };
+    db.Tags.AddRange(tagA, tagB);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var controller = await CreateController(db);
+
+    // Create task with tagA
+    var createResult = (await controller.CreateTrackedTask(new CreateTrackedTaskDto
+    {
+        Name = "Replace Test",
+        StartDate = DateTimeOffset.UtcNow,
+        Duration = TimeSpan.FromHours(1),
+        TagIds = new List<string> { tagA.TagId }
+    })).Result as OkObjectResult;
+    var taskId = ((TrackedTaskDto)createResult!.Value!).TaskId;
+
+    // Update to only tagB
+    var updateResult = await controller.UpdateTrackedTask(new UpdateTrackedTaskDto
+    {
+        TaskId = taskId,
+        Name = "Replace Test",
+        StartDate = DateTimeOffset.UtcNow,
+        TagIds = new List<string> { tagB.TagId }
+    });
+
+    var ok = Assert.IsAssignableFrom<OkObjectResult>(updateResult.Result);
+    var updated = Assert.IsAssignableFrom<TrackedTaskDto>(ok.Value);
+    Assert.Single(updated.Tags);
+    Assert.Equal("beta", updated.Tags[0].Name);
+}
+
+[Fact]
+public async Task Search_Tasks_By_TagId_Returns_Matching_Tasks_Test()
+{
+    var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_SearchByTag");
+    var tag = new Tag { Name = "urgent", Color = "#EC4899", UserId = "ApplicationUser1" };
+    db.Tags.Add(tag);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var controller = await CreateController(db);
+    await controller.CreateTrackedTask(new CreateTrackedTaskDto
+    {
+        Name = "Urgent Task",
+        StartDate = DateTimeOffset.UtcNow,
+        Duration = TimeSpan.FromHours(1),
+        TagIds = new List<string> { tag.TagId }
+    });
+
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+    var searchResult = await controller.SearchTrackedTasks(
+        pagingParams, null, null, null, null, new List<string> { tag.TagId });
+
+    var ok = Assert.IsAssignableFrom<OkObjectResult>(searchResult.Result);
+    var tasks = Assert.IsAssignableFrom<IEnumerable<TrackedTaskDto>>(ok.Value).ToList();
+    Assert.Contains(tasks, t => t.Name == "Urgent Task");
+}
+
+[Fact]
+public async Task Search_Tasks_By_TagId_Excludes_Untagged_Tasks_Test()
+{
+    var db = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "_SearchExclude");
+    var tag = new Tag { Name = "filter", Color = "#6366F1", UserId = "ApplicationUser1" };
+    db.Tags.Add(tag);
+    await db.SaveChangesAsync();
+    db.ChangeTracker.Clear();
+
+    var controller = await CreateController(db);
+    var pagingParams = new PagingParameters { PageSize = 100, PageNumber = 1 };
+
+    // None of the seeded tasks have this tag
+    var searchResult = await controller.SearchTrackedTasks(
+        pagingParams, null, null, null, null, new List<string> { tag.TagId });
+
+    var ok = Assert.IsAssignableFrom<OkObjectResult>(searchResult.Result);
+    var tasks = Assert.IsAssignableFrom<IEnumerable<TrackedTaskDto>>(ok.Value).ToList();
+    Assert.Empty(tasks);
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "FullyQualifiedName~TrackedTaskControllerTest" -v m
+```
+
+Expected: FAIL — `SearchTrackedTasks` signature mismatch (no `tagIds` param yet), `TrackedTaskController` constructor mismatch.
+
+- [ ] **Step 3: Update TrackedTaskController**
+
+In `TrackedTaskController.cs`:
+
+**3a.** Add `ApplicationDbContext dbContext` as a 5th constructor parameter and field:
+
+```csharp
+// Add field:
+private readonly ApplicationDbContext dbContext;
+
+// Update constructor signature from:
+public TrackedTaskController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TrackedTaskController> logger, IConfiguration configuration)
+// to:
+public TrackedTaskController(IRepositoryFactory repositoryFactory, IMapper mapper, ILogger<TrackedTaskController> logger, IConfiguration configuration, ApplicationDbContext dbContext)
+{
+    // ... existing assignments ...
+    this.dbContext = dbContext;
+}
+```
+
+**3b.** In `GetTrackedTasks`, update the `includeProperties` from `"Project"` to `"Project,Tags"`:
+
+```csharp
+var pagedTrackedTaskList = await taskRepository.GetPaged(trackedTaskParameters,
+    trackedTask => trackedTask.UserId == userId,
+    orderBy: $"{nameof(TrackedTask.StartDate)} desc",
+    includeProperties: "Project,Tags");   // added Tags
+```
+
+**3c.** In `SearchTrackedTasks`, add `[FromQuery] List<string>? tagIds = null` parameter, update `includeProperties`, and add the tag filter:
+
+```csharp
+[HttpGet("search")]
+public async Task<ActionResult<IEnumerable<TrackedTaskDto>>> SearchTrackedTasks(
+    [FromQuery] PagingParameters pagingParameters,
+    [FromQuery] DateTimeOffset? from = null,
+    [FromQuery] DateTimeOffset? to = null,
+    [FromQuery] string? projectId = null,
+    [FromQuery] string? search = null,
+    [FromQuery] List<string>? tagIds = null)
+{
+    var userId = User.FindFirstValue(Constants.Claims.UserId);
+    if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+    var normalizedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+    var normalizedProjectId = string.IsNullOrWhiteSpace(projectId) ? null : projectId.Trim();
+    var hasTagFilter = tagIds != null && tagIds.Any();
+
+    var pagedTrackedTaskList = await taskRepository.GetPaged(pagingParameters,
+        t => t.UserId == userId
+            && (from == null || t.StartDate >= from.Value.ToUniversalTime())
+            && (to == null || t.StartDate <= to.Value.ToUniversalTime())
+            && (normalizedProjectId == null || t.ProjectId == normalizedProjectId)
+            && (normalizedSearch == null || t.Name.Contains(normalizedSearch))
+            && (!hasTagFilter || t.Tags.Any(tag => tagIds!.Contains(tag.TagId))),
+        orderBy: $"{nameof(TrackedTask.StartDate)} desc",
+        includeProperties: "Project,Tags");
+
+    var metadata = new PaginationHeaderDto { /* ... same as before ... */ };
+    Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metadata));
+    return Ok(mapper.Map<IEnumerable<TrackedTaskDto>>(pagedTrackedTaskList));
+}
+```
+
+Note: Copy the existing `PaginationHeaderDto` population from the current method — only the `includeProperties` and filter predicate change.
+
+**3d.** In `CreateTrackedTask`, add tag sync after `await taskRepository.Insert(newTrackedTask)`:
+
+```csharp
+await taskRepository.Insert(newTrackedTask);
+
+// Sync tags (tracked context required for M2M)
+if (trackedTask.TagIds.Any())
+{
+    var tracked = await dbContext.TrackedTasks
+        .AsTracking()
+        .Include(t => t.Tags)
+        .FirstAsync(t => t.TaskId == newTrackedTask.TaskId);
+
+    var newTags = await dbContext.Tags
+        .Where(t => t.UserId == userId && trackedTask.TagIds.Contains(t.TagId))
+        .ToListAsync();
+
+    foreach (var tag in newTags)
+        tracked.Tags.Add(tag);
+
+    await dbContext.SaveChangesAsync();
+}
+
+// Reload with full includes for the response DTO
+var result = await taskRepository.GetByIdInclude(
+    t => t.TaskId == newTrackedTask.TaskId, "Project,Tags");
+return Ok(mapper.Map<TrackedTaskDto>(result));
+```
+
+**3e.** In `UpdateTrackedTask`, switch from `taskRepository.Find` / `taskRepository.Update` to a tracked query (for M2M sync). Replace the current lookup-and-update block:
+
+```csharp
+// Replace:
+var foundTrackedTask = await taskRepository.Find(trackedTask.TaskId);
+// ... validation ...
+mapper.Map(trackedTask, foundTrackedTask);
+// ... date logic ...
+await taskRepository.Update(foundTrackedTask);
+return Ok(mapper.Map<TrackedTaskDto>(foundTrackedTask));
+
+// With:
+// Load with tracking + Tags for M2M sync
+var foundTrackedTask = await dbContext.TrackedTasks
+    .AsTracking()
+    .Include(t => t.Tags)
+    .FirstOrDefaultAsync(t => t.TaskId == trackedTask.TaskId && !t.DeletedAt.HasValue);
+
+if (foundTrackedTask == null) return NotFound("Tracked task not found!");
+if (foundTrackedTask.UserId != userId) return NotFound("Tracked task not found!");
+
+// Update scalar fields
+mapper.Map(trackedTask, foundTrackedTask);
+foundTrackedTask.StartDate = foundTrackedTask.StartDate.ToUniversalTime();
+if (foundTrackedTask.EndDate.HasValue)
+{
+    foundTrackedTask.EndDate = foundTrackedTask.EndDate.Value.ToUniversalTime();
+    if (foundTrackedTask.EndDate.Value <= foundTrackedTask.StartDate)
+        return BadRequest("End date must be strictly after start date.");
+    foundTrackedTask.Duration = foundTrackedTask.EndDate.Value - foundTrackedTask.StartDate;
+}
+
+// Sync tags: clear then add new set
+foundTrackedTask.Tags.Clear();
+if (trackedTask.TagIds.Any())
+{
+    var newTags = await dbContext.Tags
+        .Where(t => t.UserId == userId && trackedTask.TagIds.Contains(t.TagId))
+        .ToListAsync();
+    foreach (var tag in newTags)
+        foundTrackedTask.Tags.Add(tag);
+}
+
+await dbContext.SaveChangesAsync();
+
+// Reload for full includes in the response DTO
+var result = await taskRepository.GetByIdInclude(
+    t => t.TaskId == foundTrackedTask.TaskId, "Project,Tags");
+return Ok(mapper.Map<TrackedTaskDto>(result));
+```
+
+Add `using Microsoft.EntityFrameworkCore;` if not present.
+
+- [ ] **Step 4: Update TrackedTaskControllerTest.CreateController to pass dbContext**
+
+In `TrackedTaskControllerTest.cs`, update `CreateController` to pass `applicationDbContext` as the 5th arg:
+
+```csharp
+protected override async Task<TrackedTaskController> CreateController(
+    ApplicationDbContext? applicationDbContext = null,
+    string userId = "ApplicationUser1")
+{
+    if (applicationDbContext == null)
+        applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName);
+
+    var repositoryFactory = new RepositoryFactory(applicationDbContext);
+    var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+    {
+        new Claim("sub", userId),
+        new Claim(ClaimTypes.Name, "test1@email.com")
+    }));
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?> { ["TrashRetention:Days"] = "30" })
+        .Build();
+
+    return new TrackedTaskController(repositoryFactory, _mapper, _loggerMock.Object, configuration, applicationDbContext)
+    {
+        ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = user }
+        }
+    };
+}
+```
+
+- [ ] **Step 5: Run all TrackedTaskController tests**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj --filter "FullyQualifiedName~TrackedTaskControllerTest" -v m
+```
+
+Expected: All tests pass, including the 5 new tag tests.
+
+- [ ] **Step 6: Run all Server.Tests for regression check**
+
+```
+dotnet test Timinute\Server.Tests\Timinute.Server.Tests.csproj -v m
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Timinute/Server/Controllers/TrackedTaskController.cs Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+git commit -m "feat: TrackedTaskController tag includes, search filter, and tag sync
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 9: Client API Constants + AuroraIcons "tag"
+
+**Files:**
+- Modify: `Timinute/Client/Helpers/Constants.cs`
+- Modify: `Timinute/Client/Shared/AuroraIcons.razor`
+
+- [ ] **Step 1: Add Tag API constants**
+
+In `Constants.cs`, inside the `API` class, add after `public static class Project { ... }`:
+
+```csharp
+public static class Tag
+{
+    public const string Get    = "Tag";
+    public const string Create = "Tag";
+    public const string Update = "Tag";
+    public static string GetById(string id)    => $"Tag/{id}";
+    public static string Delete(string id)     => $"Tag/{id}";
+    public static string DeleteForce(string id) => $"Tag/{id}?force=true";
+}
+```
+
+- [ ] **Step 2: Add "tag" icon to AuroraIcons.razor**
+
+In `AuroraIcons.razor`, add a new `case` inside the `@switch` block before the final `}`:
+
+```razor
+case "tag":
+    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+    <line x1="7" y1="7" x2="7.01" y2="7" />
+    break;
+```
+
+- [ ] **Step 3: Build Client project**
+
+```
+dotnet build Timinute\Client\Timinute.Client.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Client/Helpers/Constants.cs Timinute/Client/Shared/AuroraIcons.razor
+git commit -m "feat: add Tag API constants and tag icon to AuroraIcons
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 10: Tags Management Page + NavMenu
+
+**Files:**
+- Create: `Timinute/Client/Pages/Tags/Tags.razor`
+- Create: `Timinute/Client/Pages/Tags/Tags.razor.css`
+- Modify: `Timinute/Client/Shared/NavMenu.razor`
+
+- [ ] **Step 1: Create Tags.razor**
+
+Create `Timinute/Client/Pages/Tags/Tags.razor`:
+
+```razor
+@page "/tags"
+@attribute [Authorize]
+
+@using Timinute.Client.Helpers
+@using Timinute.Shared.Dtos.Tag
+
+@inject IHttpClientFactory ClientFactory
+@inject Radzen.NotificationService Notifier
+@inject Radzen.DialogService DialogService
+
+<PageTitle>Tags</PageTitle>
+
+<div class="aurora-tags-page">
+    <div class="aurora-tags-header">
+        <h2 class="aurora-tags-title">Tags</h2>
+        <AuroraButton Variant="primary" OnClick="OpenCreateForm">
+            <AuroraIcons Name="plus" Size="16" />
+            <span>New tag</span>
+        </AuroraButton>
+    </div>
+
+    @if (IsLoading)
+    {
+        <div class="aurora-tags-loading">Loading…</div>
+    }
+    else if (Tags.Count == 0)
+    {
+        <AuroraCard>
+            <div class="aurora-tags-empty">No tags yet. Create one to get started.</div>
+        </AuroraCard>
+    }
+    else
+    {
+        <AuroraCard NoPad="true">
+            @foreach (var tag in Tags)
+            {
+                <div class="aurora-tags-row">
+                    <span class="aurora-tags-row__pill" style="--tag-color: @tag.Color;">
+                        <span class="aurora-tags-row__dot" style="background: @tag.Color;"></span>
+                        @tag.Name
+                    </span>
+                    <span class="aurora-tags-row__count">@tag.TaskCount task@(tag.TaskCount == 1 ? "" : "s")</span>
+                    <div class="aurora-tags-row__actions">
+                        <button class="aurora-tt-icon-btn" title="Edit" @onclick="() => OpenEditForm(tag)">
+                            <AuroraIcons Name="edit" Size="14" />
+                        </button>
+                        <button class="aurora-tt-icon-btn aurora-tt-icon-btn--danger" title="Delete" @onclick="() => ConfirmDelete(tag)">
+                            <AuroraIcons Name="trash" Size="14" />
+                        </button>
+                    </div>
+                </div>
+            }
+        </AuroraCard>
+    }
+
+    @if (ShowForm)
+    {
+        <AuroraCard>
+            <div class="aurora-tags-form">
+                <input class="aurora-tags-form__name" type="text" placeholder="Tag name"
+                       maxlength="30" @bind="FormName" @bind:event="oninput" />
+                <input class="aurora-tags-form__color" type="color" @bind="FormColor" />
+                <AuroraButton Variant="primary" OnClick="SubmitForm"
+                              Disabled="@(string.IsNullOrWhiteSpace(FormName))">
+                    @(EditingTagId == null ? "Create" : "Save")
+                </AuroraButton>
+                <AuroraButton Variant="ghost" OnClick="CancelForm">Cancel</AuroraButton>
+            </div>
+        </AuroraCard>
+    }
+</div>
+
+@code {
+    private bool IsLoading = true;
+    private List<TagDto> Tags = new();
+    private bool ShowForm = false;
+    private string FormName = "";
+    private string FormColor = "#6366F1";
+    private string? EditingTagId = null;
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private async Task Reload()
+    {
+        IsLoading = true;
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            Tags = await client.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Could not load tags", ex.Message, 4000);
+            Tags = new();
+        }
+        IsLoading = false;
+    }
+
+    private void OpenCreateForm()
+    {
+        EditingTagId = null;
+        FormName = "";
+        FormColor = "#6366F1";
+        ShowForm = true;
+    }
+
+    private void OpenEditForm(TagDto tag)
+    {
+        EditingTagId = tag.TagId;
+        FormName = tag.Name;
+        FormColor = tag.Color;
+        ShowForm = true;
+    }
+
+    private void CancelForm() => ShowForm = false;
+
+    private async Task SubmitForm()
+    {
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            HttpResponseMessage resp;
+            if (EditingTagId == null)
+                resp = await client.PostAsJsonAsync(Constants.API.Tag.Create,
+                    new CreateTagDto { Name = FormName.Trim(), Color = FormColor });
+            else
+                resp = await client.PutAsJsonAsync(Constants.API.Tag.Update,
+                    new UpdateTagDto { TagId = EditingTagId, Name = FormName.Trim(), Color = FormColor });
+
+            if ((int)resp.StatusCode == 409)
+            {
+                Notifier.Notify(Radzen.NotificationSeverity.Warning, "Name taken",
+                    "A tag with this name already exists.", 3000);
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+            ShowForm = false;
+            Notifier.Notify(Radzen.NotificationSeverity.Success, "Saved", "Tag saved.", 2000);
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Save failed", ex.Message, 4000);
+        }
+    }
+
+    private async Task ConfirmDelete(TagDto tag)
+    {
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            // First call: get task count (force=false, returns { taskCount })
+            var checkResp = await client.DeleteAsync(Constants.API.Tag.Delete(tag.TagId));
+            if (!checkResp.IsSuccessStatusCode) return;
+
+            var body = await checkResp.Content.ReadFromJsonAsync<TaskCountResponse>();
+            int count = body?.TaskCount ?? 0;
+
+            if (count > 0)
+            {
+                bool? confirmed = await DialogService.Confirm(
+                    $"This tag is used on {count} task{(count == 1 ? "" : "s")}. Deleting it will remove it from those tasks. Continue?",
+                    "Delete tag",
+                    new Radzen.ConfirmOptions { OkButtonText = "Delete", CancelButtonText = "Cancel" });
+                if (confirmed != true) return;
+            }
+
+            var forceResp = await client.DeleteAsync(Constants.API.Tag.DeleteForce(tag.TagId));
+            forceResp.EnsureSuccessStatusCode();
+            Notifier.Notify(Radzen.NotificationSeverity.Success, "Deleted", $"Tag \"{tag.Name}\" deleted.", 2000);
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Delete failed", ex.Message, 4000);
+        }
+    }
+
+    private record TaskCountResponse(int TaskCount);
+}
+```
+
+- [ ] **Step 2: Create Tags.razor.css**
+
+Create `Timinute/Client/Pages/Tags/Tags.razor.css`:
+
+```css
+.aurora-tags-page {
+    padding: 24px;
+    max-width: 640px;
+}
+
+.aurora-tags-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.aurora-tags-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.aurora-tags-loading,
+.aurora-tags-empty {
+    padding: 32px;
+    text-align: center;
+    color: var(--aurora-muted);
+}
+
+.aurora-tags-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--aurora-border);
+}
+
+.aurora-tags-row:last-child { border-bottom: none; }
+
+.aurora-tags-row__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    display: inline-block;
+}
+
+.aurora-tags-row__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: color-mix(in srgb, var(--tag-color) 15%, transparent);
+    color: var(--tag-color);
+    border: 1px solid color-mix(in srgb, var(--tag-color) 40%, transparent);
+    border-radius: 999px;
+    padding: 3px 10px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.aurora-tags-row__count {
+    color: var(--aurora-muted);
+    font-size: 0.8rem;
+    flex: 1;
+}
+
+.aurora-tags-row__actions { display: flex; gap: 4px; }
+
+.aurora-tags-form {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 4px;
+}
+
+.aurora-tags-form__name {
+    flex: 1;
+    min-width: 160px;
+    padding: 8px 12px;
+    border: 1px solid var(--aurora-border);
+    border-radius: 8px;
+    background: var(--aurora-input-bg, var(--aurora-surface));
+    color: var(--aurora-text);
+    font-size: 0.9rem;
+}
+
+.aurora-tags-form__color {
+    width: 36px;
+    height: 36px;
+    border: none;
+    padding: 0;
+    border-radius: 6px;
+    cursor: pointer;
+}
+```
+
+- [ ] **Step 3: Add Tags nav item to NavMenu.razor**
+
+In `NavMenu.razor`, find the `WorkspaceItems` array and add the Tags entry **after the Trash entry**:
+
+```csharp
+new("Tags", "tags", "tag", NavLinkMatch.Prefix),
+```
+
+The full array should end with:
+```csharp
+new("Trash", "trash", "trash", NavLinkMatch.Prefix),
+new("Tags",  "tags",  "tag",   NavLinkMatch.Prefix),
+```
+
+- [ ] **Step 4: Build Client project**
+
+```
+dotnet build Timinute\Client\Timinute.Client.csproj
+```
+
+Expected: Build succeeded. Fix any compile errors (check using directives at top of Tags.razor for any missing ones from the project, such as `@using Microsoft.AspNetCore.Authorization`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Client/Pages/Tags/ Timinute/Client/Shared/NavMenu.razor
+git commit -m "feat: Tags management page at /tags and sidebar nav item
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 11: TagPicker Component
+
+**Files:**
+- Create: `Timinute/Client/Components/TagPicker.razor`
+- Create: `Timinute/Client/Components/TagPicker.razor.css`
+
+- [ ] **Step 1: Create TagPicker.razor**
+
+Create `Timinute/Client/Components/TagPicker.razor`:
+
+```razor
+@using Timinute.Client.Helpers
+@using Timinute.Shared.Dtos.Tag
+
+@inject IHttpClientFactory ClientFactory
+@inject Radzen.NotificationService Notifier
+
+<div class="tag-picker">
+    @foreach (var tagId in SelectedTagIds)
+    {
+        var tag = AllTags.FirstOrDefault(t => t.TagId == tagId);
+        if (tag != null)
+        {
+            <span class="tag-picker__pill" style="--tag-color: @tag.Color;">
+                <span class="tag-picker__dot" style="background: @tag.Color;"></span>
+                @tag.Name
+                <button class="tag-picker__remove" type="button"
+                        @onclick="() => RemoveTag(tagId)"
+                        aria-label="Remove @tag.Name">×</button>
+            </span>
+        }
+    }
+
+    @if (!ShowDropdown)
+    {
+        <button class="tag-picker__add" type="button" @onclick="OpenDropdown">
+            <AuroraIcons Name="plus" Size="12" />
+            <span>Add tag</span>
+        </button>
+    }
+    else
+    {
+        <div class="tag-picker__dropdown">
+            <input class="tag-picker__search" type="text" placeholder="Search tags…"
+                   @bind="SearchText" @bind:event="oninput" @ref="searchInput" />
+
+            @foreach (var tag in FilteredUnselected)
+            {
+                <button class="tag-picker__option" type="button" @onclick="() => SelectTag(tag.TagId)">
+                    <span class="tag-picker__dot" style="background: @tag.Color;"></span>
+                    @tag.Name
+                </button>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(SearchText)
+                 && !AllTags.Any(t => t.Name.Equals(SearchText.Trim(), StringComparison.OrdinalIgnoreCase)))
+            {
+                <button class="tag-picker__option tag-picker__option--create" type="button"
+                        @onclick="CreateAndSelect">
+                    <AuroraIcons Name="plus" Size="12" />
+                    Create "@SearchText.Trim()"
+                </button>
+            }
+
+            @if (!FilteredUnselected.Any() && string.IsNullOrWhiteSpace(SearchText))
+            {
+                <div class="tag-picker__empty">No more tags</div>
+            }
+
+            <button class="tag-picker__close" type="button" @onclick="CloseDropdown">Done</button>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public List<string> SelectedTagIds { get; set; } = new();
+    [Parameter] public EventCallback<List<string>> SelectedTagIdsChanged { get; set; }
+
+    private List<TagDto> AllTags = new();
+    private bool ShowDropdown = false;
+    private string SearchText = "";
+    private ElementReference searchInput;
+
+    private IEnumerable<TagDto> FilteredUnselected =>
+        AllTags.Where(t =>
+            !SelectedTagIds.Contains(t.TagId) &&
+            (string.IsNullOrWhiteSpace(SearchText) ||
+             t.Name.Contains(SearchText.Trim(), StringComparison.OrdinalIgnoreCase)));
+
+    protected override async Task OnInitializedAsync() => await LoadTags();
+
+    private async Task LoadTags()
+    {
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            AllTags = await client.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Could not load tags", ex.Message, 3000);
+        }
+    }
+
+    private async Task OpenDropdown()
+    {
+        ShowDropdown = true;
+        SearchText = "";
+        await Task.Delay(10);
+        try { await searchInput.FocusAsync(); } catch { }
+    }
+
+    private void CloseDropdown()
+    {
+        ShowDropdown = false;
+        SearchText = "";
+    }
+
+    private async Task SelectTag(string tagId)
+    {
+        if (!SelectedTagIds.Contains(tagId))
+            await SelectedTagIdsChanged.InvokeAsync(new List<string>(SelectedTagIds) { tagId });
+    }
+
+    private async Task RemoveTag(string tagId) =>
+        await SelectedTagIdsChanged.InvokeAsync(SelectedTagIds.Where(id => id != tagId).ToList());
+
+    private async Task CreateAndSelect()
+    {
+        var name = SearchText.Trim();
+        if (string.IsNullOrWhiteSpace(name)) return;
+
+        var client = ClientFactory.CreateClient(Constants.API.ClientName);
+        try
+        {
+            var resp = await client.PostAsJsonAsync(Constants.API.Tag.Create,
+                new CreateTagDto { Name = name, Color = "#6366F1" });
+
+            if ((int)resp.StatusCode == 409)
+            {
+                Notifier.Notify(Radzen.NotificationSeverity.Warning, "Name taken",
+                    $"Tag \"{name}\" already exists.", 3000);
+                return;
+            }
+            resp.EnsureSuccessStatusCode();
+
+            var created = await resp.Content.ReadFromJsonAsync<TagDto>();
+            if (created != null)
+            {
+                AllTags.Add(created);
+                AllTags = AllTags.OrderBy(t => t.Name).ToList();
+                await SelectTag(created.TagId);
+            }
+            SearchText = "";
+        }
+        catch (Exception ex)
+        {
+            Notifier.Notify(Radzen.NotificationSeverity.Error, "Create failed", ex.Message, 3000);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create TagPicker.razor.css**
+
+Create `Timinute/Client/Components/TagPicker.razor.css`:
+
+```css
+.tag-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    position: relative;
+}
+
+.tag-picker__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: color-mix(in srgb, var(--tag-color) 15%, transparent);
+    color: var(--tag-color);
+    border: 1px solid color-mix(in srgb, var(--tag-color) 40%, transparent);
+    border-radius: 999px;
+    padding: 3px 8px;
+    font-size: 0.78rem;
+    font-weight: 500;
+}
+
+.tag-picker__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.tag-picker__remove {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0 0 0 2px;
+    line-height: 1;
+    opacity: 0.7;
+}
+.tag-picker__remove:hover { opacity: 1; }
+
+.tag-picker__add {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: 1px dashed var(--aurora-border);
+    background: none;
+    color: var(--aurora-muted);
+    border-radius: 999px;
+    padding: 3px 10px;
+    font-size: 0.78rem;
+    cursor: pointer;
+}
+.tag-picker__add:hover { border-color: var(--aurora-text); color: var(--aurora-text); }
+
+.tag-picker__dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 50;
+    background: var(--aurora-surface);
+    border: 1px solid var(--aurora-border);
+    border-radius: 10px;
+    padding: 8px;
+    min-width: 200px;
+    max-height: 240px;
+    overflow-y: auto;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.tag-picker__search {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--aurora-border);
+    border-radius: 6px;
+    background: var(--aurora-input-bg, var(--aurora-surface));
+    color: var(--aurora-text);
+    font-size: 0.85rem;
+    margin-bottom: 4px;
+}
+
+.tag-picker__option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: none;
+    border: none;
+    color: var(--aurora-text);
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    text-align: left;
+    width: 100%;
+}
+.tag-picker__option:hover { background: var(--aurora-hover); }
+.tag-picker__option--create { color: var(--aurora-primary); }
+
+.tag-picker__empty {
+    color: var(--aurora-muted);
+    font-size: 0.8rem;
+    text-align: center;
+    padding: 8px;
+}
+
+.tag-picker__close {
+    margin-top: 4px;
+    background: none;
+    border: 1px solid var(--aurora-border);
+    border-radius: 6px;
+    color: var(--aurora-muted);
+    padding: 4px 8px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    align-self: flex-end;
+}
+```
+
+- [ ] **Step 3: Build Client project**
+
+```
+dotnet build Timinute\Client\Timinute.Client.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Timinute/Client/Components/TagPicker.razor Timinute/Client/Components/TagPicker.razor.css
+git commit -m "feat: TagPicker inline component for tag assignment in task forms
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 12: Task Modal Tag Integration
+
+**Files:**
+- Modify: `Timinute/Client/Models/TrackedTask.cs`
+- Modify: `Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor`
+- Modify: `Timinute/Client/Components/TrackedTasks/AddTrackedTask.razor.cs`
+- Modify: `Timinute/Client/Components/Scheduler/EditTrackedTaskForm.razor`
+
+The edit dialog passes `TrackedTask` (client model) to `EditTrackedTaskForm`, and receives the modified model back via `DialogService.Close(model)`. `TrackedTasks.razor` then builds `UpdateTrackedTaskDto` from the returned model. So `Client.Models.TrackedTask` needs `TagIds` and the constructor needs to populate it from the DTO's `Tags`.
+
+- [ ] **Step 1: Update Client.Models.TrackedTask**
+
+In `Timinute/Client/Models/TrackedTask.cs`:
+
+Add the using and fields:
+```csharp
+using Timinute.Shared.Dtos.Tag;
+```
+
+Add properties before the constructors:
+```csharp
+public List<TagDto> Tags { get; set; } = new();
+public List<string> TagIds { get; set; } = new();
+```
+
+In the `TrackedTask(TrackedTaskDto trackedTask)` constructor, add after the existing assignments:
+```csharp
+Tags = trackedTask.Tags ?? new();
+TagIds = trackedTask.Tags?.Select(t => t.TagId).ToList() ?? new();
+```
+
+- [ ] **Step 2: Add TagPicker to AddTrackedTask.razor**
+
+In `AddTrackedTask.razor`, add `@using Timinute.Client.Components` at the top if not present.
+
+Add the TagPicker after the project dropdown div (before the submit button row):
+
+```razor
+<div class="col-auto" style="margin-top: 8px;">
+    <TagPicker SelectedTagIds="@SelectedTagIds"
+               SelectedTagIdsChanged="@(ids => SelectedTagIds = ids)" />
+</div>
+```
+
+- [ ] **Step 3: Update AddTrackedTask.razor.cs**
+
+In `AddTrackedTask.razor.cs`:
+
+Add the field:
+```csharp
+private List<string> SelectedTagIds { get; set; } = new();
+```
+
+In `HandleValidSubmit` (where `CreateTrackedTaskDto` is built), add `TagIds`:
+```csharp
+CreateTrackedTaskDto createTrackedTaskDto = new()
+{
+    Name = NewTrackedTask.Name,
+    ProjectId = SelectedProjectId,
+    StartDate = NewTrackedTask.StartDate,
+    Duration = NewTrackedTask.Duration,
+    TagIds = SelectedTagIds        // ADD THIS LINE
+};
+```
+
+After the task is successfully created, reset tags alongside the rest of the form:
+```csharp
+SelectedTagIds = new();
+```
+
+- [ ] **Step 4: Add TagPicker to EditTrackedTaskForm.razor**
+
+In `EditTrackedTaskForm.razor`:
+
+Add `@using Timinute.Client.Components` at the top.
+
+Add a `selectedTagIds` field in `@code`:
+```csharp
+private List<string> selectedTagIds = new();
+```
+
+In `OnParametersSet`, populate it:
+```csharp
+protected override void OnParametersSet()
+{
+    model = TrackedTask;
+    selectedTagIds = TrackedTask.TagIds ?? new();
+}
+```
+
+Add the TagPicker row after the Project row (before the submit row):
+```razor
+<div class="row" style="margin-bottom: 16px">
+    <div class="col-md-3">
+        <RadzenLabel Text="Tags" />
+    </div>
+    <div class="col">
+        <TagPicker SelectedTagIds="@selectedTagIds"
+                   SelectedTagIdsChanged="@(ids => { selectedTagIds = ids; StateHasChanged(); })" />
+    </div>
+</div>
+```
+
+In `OnSubmit`, set `model.TagIds` before closing:
+```csharp
+void OnSubmit(TrackedTask model)
+{
+    model.TagIds = selectedTagIds;
+    DialogService.Close(model);
+}
+```
+
+- [ ] **Step 5: Update TrackedTasks.razor to pass TagIds on update**
+
+In `TrackedTasks.razor`, in the `EditTask` method where `UpdateTrackedTaskDto` is built, add `TagIds`:
+
+```csharp
+var dto = new UpdateTrackedTaskDto
+{
+    TaskId   = updated.TaskId,
+    Name     = updated.Name,
+    StartDate = updated.StartDate,
+    EndDate  = updated.EndDate,
+    ProjectId = updated.ProjectId,
+    TagIds   = updated.TagIds      // ADD THIS LINE
+};
+```
+
+- [ ] **Step 6: Build Client project**
+
+```
+dotnet build Timinute\Client\Timinute.Client.csproj
+```
+
+Expected: Build succeeded. If there are any missing `using` directives, add them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Timinute/Client/Models/TrackedTask.cs Timinute/Client/Components/TrackedTasks/ Timinute/Client/Components/Scheduler/EditTrackedTaskForm.razor Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor
+git commit -m "feat: integrate TagPicker into AddTrackedTask and EditTrackedTaskForm
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 13: TrackedTasks Tag Filter Chips
+
+**Files:**
+- Modify: `Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor`
+- Modify: `Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css`
+
+- [ ] **Step 1: Add tag filter state and loading to the @code block**
+
+Add `@using Timinute.Shared.Dtos.Tag` at the top of `TrackedTasks.razor` if not present.
+
+In the `@code` block, add fields:
+```csharp
+private List<TagDto> AllUserTags = new();
+private List<string> ActiveTagIds = new();
+```
+
+Update `OnInitializedAsync` to load tags in parallel:
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    await Task.WhenAll(Reload(), LoadTags());
+}
+
+private async Task LoadTags()
+{
+    var client = ClientFactory.CreateClient(Constants.API.ClientName);
+    try
+    {
+        AllUserTags = await client.GetFromJsonAsync<List<TagDto>>(Constants.API.Tag.Get) ?? new();
+    }
+    catch { /* non-critical: tag chips are optional */ }
+}
+
+private async Task ToggleTag(string tagId)
+{
+    if (ActiveTagIds.Contains(tagId))
+        ActiveTagIds.Remove(tagId);
+    else
+        ActiveTagIds.Add(tagId);
+    await Reload();
+}
+```
+
+Update `Reload()` to use the search endpoint when tags are active:
+```csharp
+private async Task Reload()
+{
+    IsLoading = true;
+    var client = ClientFactory.CreateClient(Constants.API.ClientName);
+    try
+    {
+        if (ActiveTagIds.Any())
+        {
+            var query = string.Join("&", ActiveTagIds.Select(id => $"tagIds={Uri.EscapeDataString(id)}"));
+            AllTasks = await client.GetAllPagedAsync<TrackedTaskDto>(
+                $"{Constants.API.TrackedTask.Get}/search?{query}");
+        }
+        else
+        {
+            AllTasks = await client.GetAllPagedAsync<TrackedTaskDto>(Constants.API.TrackedTask.Get);
+        }
+    }
+    catch (Exception ex)
+    {
+        Notifier.Notify(Radzen.NotificationSeverity.Error, "Could not load", ex.Message, 4000);
+        AllTasks = new();
+    }
+    IsLoading = false;
+    StateHasChanged();
+}
+```
+
+Also update the `FilteredGroups` text filter to include tags:
+```csharp
+if (!string.IsNullOrEmpty(f))
+{
+    source = source.Where(t =>
+        t.Name.Contains(f, StringComparison.OrdinalIgnoreCase)
+        || (t.Project?.Name?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+        || t.Tags.Any(tag => tag.Name.Contains(f, StringComparison.OrdinalIgnoreCase)));
+}
+```
+
+- [ ] **Step 2: Add tag filter chips to the filter bar markup**
+
+In `TrackedTasks.razor`, inside the filter bar `<div class="aurora-tt-filter">`, add tag chips after the last `<AuroraButton>` (the Export button) and before `<div style="flex: 1;"></div>`:
+
+```razor
+@if (AllUserTags.Any())
+{
+    <div class="aurora-tt-filter__tags">
+        @foreach (var tag in AllUserTags)
+        {
+            var isActive = ActiveTagIds.Contains(tag.TagId);
+            <button class="aurora-tt-tag-chip @(isActive ? "is-active" : "")"
+                    style="--tag-color: @tag.Color;"
+                    @onclick="() => ToggleTag(tag.TagId)">
+                <span class="aurora-tt-tag-chip__dot" style="background: @tag.Color;"></span>
+                @tag.Name
+            </button>
+        }
+    </div>
+}
+```
+
+- [ ] **Step 3: Add tag chip styles to TrackedTasks.razor.css**
+
+In `TrackedTasks.razor.css`, add:
+
+```css
+.aurora-tt-filter__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.aurora-tt-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid color-mix(in srgb, var(--tag-color) 40%, transparent);
+    background: none;
+    color: var(--tag-color);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.aurora-tt-tag-chip.is-active {
+    background: color-mix(in srgb, var(--tag-color) 20%, transparent);
+    font-weight: 600;
+}
+
+.aurora-tt-tag-chip__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+}
+```
+
+- [ ] **Step 4: Build Client project**
+
+```
+dotnet build Timinute\Client\Timinute.Client.csproj
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor Timinute/Client/Pages/TrackedTasks/TrackedTasks.razor.css
+git commit -m "feat: tag filter chips on TrackedTasks page with server-side filtering
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 14: TagPicker Component Tests (bUnit)
+
+**Files:**
+- Modify: `Timinute/Client.Tests/Timinute.Client.Tests.csproj`
+- Create: `Timinute/Client.Tests/Components/TagPickerTest.cs`
+
+- [ ] **Step 1: Add bUnit and change SDK to Razor in Client.Tests.csproj**
+
+In `Timinute.Client.Tests.csproj`:
+
+**1a.** Change the first line from:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+```
+to:
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+```
+
+**1b.** Add the bUnit package reference inside `<ItemGroup>`:
+```xml
+<PackageReference Include="bunit" Version="1.28.9" />
+```
+
+Run restore:
+```
+dotnet restore Timinute\Client.Tests\Timinute.Client.Tests.csproj
+```
+
+- [ ] **Step 2: Create the test file**
+
+Create `Timinute/Client.Tests/Components/TagPickerTest.cs`:
+
+```csharp
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Radzen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Timinute.Client.Components;
+using Timinute.Shared.Dtos.Tag;
+using Xunit;
+
+namespace Timinute.Client.Tests.Components
+{
+    public class TagPickerTest : TestContext
+    {
+        private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+        public TagPickerTest()
+        {
+            Services.AddSingleton(new Mock<NotificationService>().Object);
+        }
+
+        private void SetupHttpClient(List<TagDto> tags)
+        {
+            var handler = new FakeTagHandler(tags);
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            Services.AddSingleton<IHttpClientFactory>(
+                new FakeHttpClientFactory(Timinute.Client.Helpers.Constants.API.ClientName, client));
+        }
+
+        [Fact]
+        public void TagPicker_Renders_Selected_Tag_As_Pill()
+        {
+            var tags = new List<TagDto>
+            {
+                new() { TagId = "tag1", Name = "work",   Color = "#6366F1", TaskCount = 0 },
+                new() { TagId = "tag2", Name = "urgent", Color = "#EC4899", TaskCount = 0 }
+            };
+            SetupHttpClient(tags);
+
+            var cut = RenderComponent<TagPicker>(p => p
+                .Add(x => x.SelectedTagIds, new List<string> { "tag1" }));
+
+            // "work" pill should be visible
+            var pills = cut.FindAll(".tag-picker__pill");
+            Assert.Single(pills);
+            Assert.Contains("work", pills[0].TextContent);
+        }
+
+        [Fact]
+        public void TagPicker_Remove_Pill_Raises_SelectedTagIdsChanged()
+        {
+            var tags = new List<TagDto>
+            {
+                new() { TagId = "tag1", Name = "work", Color = "#6366F1", TaskCount = 0 }
+            };
+            SetupHttpClient(tags);
+
+            List<string>? emitted = null;
+            var cut = RenderComponent<TagPicker>(p => p
+                .Add(x => x.SelectedTagIds, new List<string> { "tag1" })
+                .Add(x => x.SelectedTagIdsChanged,
+                    EventCallback.Factory.Create<List<string>>(this, ids => emitted = ids)));
+
+            cut.Find(".tag-picker__remove").Click();
+
+            Assert.NotNull(emitted);
+            Assert.Empty(emitted!);
+        }
+
+        [Fact]
+        public void TagPicker_Select_From_Dropdown_Raises_SelectedTagIdsChanged()
+        {
+            var tags = new List<TagDto>
+            {
+                new() { TagId = "tag1", Name = "work",   Color = "#6366F1", TaskCount = 0 },
+                new() { TagId = "tag2", Name = "urgent", Color = "#EC4899", TaskCount = 0 }
+            };
+            SetupHttpClient(tags);
+
+            List<string>? emitted = null;
+            var cut = RenderComponent<TagPicker>(p => p
+                .Add(x => x.SelectedTagIds, new List<string> { "tag1" }) // tag1 already selected
+                .Add(x => x.SelectedTagIdsChanged,
+                    EventCallback.Factory.Create<List<string>>(this, ids => emitted = ids)));
+
+            // Open dropdown
+            cut.Find(".tag-picker__add").Click();
+
+            // "urgent" option should appear (tag1 is already selected, so only tag2 shows)
+            var options = cut.FindAll(".tag-picker__option");
+            var urgentOption = options.FirstOrDefault(o => o.TextContent.Contains("urgent"));
+            Assert.NotNull(urgentOption);
+            urgentOption!.Click();
+
+            Assert.NotNull(emitted);
+            Assert.Contains("tag2", emitted!);
+            Assert.Contains("tag1", emitted!); // existing selection preserved
+        }
+    }
+
+    internal sealed class FakeTagHandler : HttpMessageHandler
+    {
+        private readonly List<TagDto> _tags;
+        private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+        public FakeTagHandler(List<TagDto> tags) => _tags = tags;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(_tags, options: WebJson)
+            };
+            return Task.FromResult(resp);
+        }
+    }
+
+    internal sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly string _name;
+        private readonly HttpClient _client;
+
+        public FakeHttpClientFactory(string name, HttpClient client)
+        {
+            _name = name;
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name) => _client;
+    }
+}
+```
+
+- [ ] **Step 3: Run TagPicker tests**
+
+```
+dotnet test Timinute\Client.Tests\Timinute.Client.Tests.csproj --filter "FullyQualifiedName~TagPickerTest" -v m
+```
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 4: Run all Client.Tests for regression**
+
+```
+dotnet test Timinute\Client.Tests\Timinute.Client.Tests.csproj -v m
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Timinute/Client.Tests/
+git commit -m "test: TagPicker component tests with bUnit
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 15: Full Build + Test Verification
+
+- [ ] **Step 1: Build full solution**
+
+```
+dotnet build Timinute.sln
+```
+
+Expected: Build succeeded, 0 errors, 0 warnings (or only pre-existing warnings).
+
+- [ ] **Step 2: Run all tests**
+
+```
+dotnet test Timinute.sln -v m
+```
+
+Expected: All tests pass. Confirm the total test count is higher than before v2.2 (added: ~9 TagController tests, 2 ProjectController tests, 5 TrackedTaskController tests, 3 bUnit TagPicker tests = ~19 new tests).
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: v2.2 Tags/Labels + tech-debt — full build and all tests green
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+### Spec Coverage
+
+| Spec section | Covered in task(s) |
+|---|---|
+| §1 Tag entity (TagId, Name, Color, UserId, M2M to TrackedTask) | Task 2 |
+| §2 TagController: GET all (sorted, user-scoped) | Task 6 |
+| §2 TagController: GET by id | Task 6 |
+| §2 TagController: POST (create + 409) | Task 6 |
+| §2 TagController: PUT (update + 409) | Task 6 |
+| §2 TagController: DELETE ?force=false → task count warning | Task 6 |
+| §2 TagController: DELETE ?force=true → hard delete | Task 6 |
+| §3 TrackedTask: Tags included in GET + search | Task 8 |
+| §3 TrackedTask: tagIds filter in SearchTrackedTasks | Task 8 |
+| §3 TrackedTask: tag sync in Create | Task 8 |
+| §3 TrackedTask: tag sync in Update (replace collection) | Task 8 |
+| §4 Client: Constants.API.Tag | Task 9 |
+| §4 Client: Tags management page at /tags | Task 10 |
+| §4 Client: NavMenu sidebar Tags item | Task 10 |
+| §4 Client: TagPicker component with inline create | Task 11 |
+| §4 Client: AddTrackedTask with TagPicker | Task 12 |
+| §4 Client: EditTrackedTaskForm with TagPicker | Task 12 |
+| §4 Client: TrackedTasks filter chips (tag toggle) | Task 13 |
+| §5 DB indexes on TrackedTask.UserId, ProjectId, UserId+StartDate | Task 1 |
+| §5 DB index on Project.UserId | Task 1 |
+| §5 Unique constraint Project(UserId, Name) filtered | Task 1 |
+| §5 ProjectController 409 on duplicate name | Task 7 |
+| §6 Unit tests: TagController (≥9 cases) | Task 6 |
+| §6 Unit tests: ProjectController 409 (2 cases) | Task 7 |
+| §6 Unit tests: TrackedTaskController tag tests (5 cases) | Task 8 |
+| §6 Component tests: TagPicker (3 bUnit tests) | Task 14 |
+| EF migration covering all above | Task 3 |
+| AutoMapper Tag↔TagDto | Task 5 |

--- a/docs/superpowers/specs/2026-06-02-v2.2-tags-techdebt-design.md
+++ b/docs/superpowers/specs/2026-06-02-v2.2-tags-techdebt-design.md
@@ -1,0 +1,264 @@
+# v2.2 Design: Tags / Labels + Tech-Debt Sweep
+
+_Status: Draft — 2026-06-02_
+
+---
+
+## Scope
+
+This spec covers two parallel tracks delivered together as v2.2:
+
+1. **Tags / Labels** — a new user-scoped tagging system for tracked tasks
+2. **Tech-debt sweep** — targeted DB indexes and a unique constraint for project names
+
+---
+
+## 1. Tags / Labels
+
+### 1.1 Goals
+
+- Users can create a personal library of named, colored tags.
+- Tags can be assigned to tracked tasks (zero or more per task).
+- Tasks can be filtered by tag on the TrackedTasks page (OR logic: show tasks that have *any* of the selected tags).
+- Tags are managed from a dedicated sidebar-nav page and also created inline during task creation/editing.
+
+### 1.2 Data Model
+
+#### `Tag` entity (`Server/Models/Tag.cs`)
+
+```csharp
+public class Tag
+{
+    public string TagId { get; set; } = null!;      // GUID, ValueGeneratedOnAdd
+    public string Name { get; set; } = null!;        // max 30 chars
+    public string Color { get; set; } = null!;       // hex, e.g. "#6366F1", max 7 chars
+    public string UserId { get; set; } = null!;
+    public ApplicationUser User { get; set; } = null!;
+    public ICollection<TrackedTask> TrackedTasks { get; set; } = new List<TrackedTask>();
+}
+```
+
+- **No soft delete** — deleted tags are detached from tasks (see §1.5 Delete behaviour).
+- Unique index on `(UserId, Name)` — no duplicate tag names per user.
+
+#### `TrackedTask` — navigation addition
+
+```csharp
+public ICollection<Tag> Tags { get; set; } = new List<Tag>();
+```
+
+EF Core configures the implicit `TaskTag` join table via the many-to-many fluent API. No explicit `DbSet<TaskTag>` or model class is needed.
+
+#### EF `OnModelCreating` additions
+
+```csharp
+builder.Entity<Tag>()
+    .Property(t => t.TagId).ValueGeneratedOnAdd().IsRequired();
+
+builder.Entity<Tag>().HasKey(t => t.TagId);
+
+builder.Entity<Tag>()
+    .Property(t => t.Name).HasMaxLength(30).IsRequired();
+
+builder.Entity<Tag>()
+    .Property(t => t.Color).HasMaxLength(7).IsRequired();
+
+builder.Entity<Tag>()
+    .HasIndex(t => new { t.UserId, t.Name }).IsUnique();
+
+builder.Entity<Tag>()
+    .HasOne(t => t.User)
+    .WithMany(u => u.Tags)
+    .HasForeignKey(t => t.UserId)
+    .OnDelete(DeleteBehavior.Cascade);
+
+builder.Entity<TrackedTask>()
+    .HasMany(t => t.Tags)
+    .WithMany(tag => tag.TrackedTasks)
+    .UsingEntity("TaskTag",
+        l => l.HasOne(typeof(Tag)).WithMany().HasForeignKey("TagId")
+               .OnDelete(DeleteBehavior.Cascade),
+        r => r.HasOne(typeof(TrackedTask)).WithMany().HasForeignKey("TaskId")
+               .OnDelete(DeleteBehavior.Cascade));
+```
+
+### 1.3 DTOs (`Shared/Dtos/Tag/`)
+
+| DTO | Fields |
+|-----|--------|
+| `TagDto` | `TagId`, `Name`, `Color`, `TaskCount` (int — populated server-side in GET all) |
+| `CreateTagDto` | `Name` (`[Required]`, `[StringLength(30, MinimumLength=1)]`), `Color` (`[Required]`, hex regex `^#[0-9A-Fa-f]{6}$`) |
+| `UpdateTagDto` | `TagId` + same fields as `CreateTagDto` |
+
+`TrackedTaskDto` gains `List<TagDto> Tags`.  
+`CreateTrackedTaskDto` and `UpdateTrackedTaskDto` gain `List<string> TagIds` (optional; empty list = no tags).
+
+`MappingProfile` maps `Tag ↔ TagDto` but does **not** map `TagIds` ↔ `Tags`; tag collection sync is handled manually in the controllers.
+
+### 1.4 `TagController` (`Server/Controllers/TagController.cs`)
+
+All endpoints require `[Authorize]`. User identity resolved via `User.FindFirstValue(Constants.Claims.UserId)`.
+
+| Verb | Route | Behaviour |
+|------|-------|-----------|
+| GET | `/Tag` | Returns all tags for current user, ordered by `Name`. |
+| GET | `/Tag/{id}` | Returns single tag; 404 if not found or not owned by current user. |
+| POST | `/Tag` | Creates tag from `CreateTagDto`. Returns 409 with `{ message }` if name already exists for user. |
+| PUT | `/Tag` | Updates tag from `UpdateTagDto`. Same 409 conflict check. |
+| DELETE | `/Tag/{id}` | If `?force=false` (default): returns 200 `{ taskCount }` without deleting — client uses this to show the warning modal. If `?force=true`: deletes the `Tag` row (EF cascade removes `TaskTag` join rows). Returns 204. |
+
+Uses `IRepository<Tag>` via `RepositoryFactory`. The `force=false` task count is obtained by loading the tag with `includeProperties: "TrackedTasks"` and returning `tag.TrackedTasks.Count`.
+
+### 1.5 Delete Behaviour
+
+1. Client calls `DELETE /Tag/{id}` (no `force` param → defaults to `force=false`).
+2. Server returns `200 { taskCount: N }`.
+3. If `N > 0`, client shows a modal: *"This tag is used on N task(s). Deleting it will remove it from those tasks. Continue?"*
+4. On confirm: client calls `DELETE /Tag/{id}?force=true`.
+5. EF cascade on the `TaskTag` join table removes all associations; the `Tag` row is hard-deleted.
+
+If `N == 0`, client skips the modal and calls `DELETE /Tag/{id}?force=true` directly.
+
+### 1.6 Task Controller Changes
+
+`TrackedTaskController`:
+
+- **GET** (list + search): add `includeProperties: "Tags"` to both `GetPaged` calls; tags are mapped via AutoMapper into `TrackedTaskDto.Tags`.
+- **GET /search**: add `[FromQuery] List<string>? tagIds`. When non-empty, add filter clause: `&& (tagIds == null || !tagIds.Any() || t.Tags.Any(tag => tagIds.Contains(tag.TagId)))`.
+- **POST** (create): after inserting task, if `TagIds` non-empty, load matching `Tag` entities owned by `userId` and assign to `newTrackedTask.Tags` before saving.
+- **PUT** (update): load task with `GetByIdInclude(t => t.TaskId == trackedTask.TaskId, includeProperties: "Tags")`, clear existing tags, load new set from `TagIds`, reassign.
+
+Tag sync pattern (create/update):
+```csharp
+var tags = (await tagRepository.Get(t => t.UserId == userId && TagIds.Contains(t.TagId))).ToList();
+trackedTask.Tags = tags;
+```
+
+### 1.7 Client — New Files
+
+| File | Purpose |
+|------|---------|
+| `Shared/Dtos/Tag/TagDto.cs` | Read DTO |
+| `Shared/Dtos/Tag/CreateTagDto.cs` | Create DTO with validators |
+| `Shared/Dtos/Tag/UpdateTagDto.cs` | Update DTO |
+| `Client/Pages/Tags/Tags.razor` | Tag management page |
+| `Client/Pages/Tags/Tags.razor.css` | Scoped styles |
+| `Client/Components/TagPicker.razor` | Inline tag picker component (used in task modal) |
+| `Client/Components/TagPicker.razor.css` | Scoped styles |
+
+### 1.8 Client — Tag Management Page (`/tags`)
+
+- Listed in sidebar nav (desktop) and bottom tab bar (mobile), after **Trash** in the nav order.
+- Displays all user tags as a list: color swatch, pill preview, name, task count (`TagDto.TaskCount`).
+- **Create**: "+ New tag" button → inline form or slide-up sheet (mobile) with `Name` input + color picker (hex color `<input type="color">`).
+- **Edit**: pencil icon → same form pre-populated.
+- **Delete**: trash icon → calls `DELETE /Tag/{id}` (no force) → if `taskCount > 0` shows Aurora modal dialog with count → on confirm calls `DELETE /Tag/{id}?force=true`.
+
+`TagDto` is extended to include `int TaskCount` (populated server-side in `TagController.GetAll` via `CountAsync` for each tag, or a single grouped query).
+
+### 1.9 Client — Inline Tag Picker Component (`TagPicker.razor`)
+
+Parameters:
+```csharp
+[Parameter] public List<string> SelectedTagIds { get; set; } = new();
+[Parameter] public EventCallback<List<string>> SelectedTagIdsChanged { get; set; }
+```
+
+Behaviour:
+- Loads all user tags on first render via a direct `GET /Tag` API call; results cached in component state for the lifetime of the picker (no cross-component cache needed).
+- Renders selected tags as removable pills (color-tinted background, color dot, name, × remove button).
+- "+ Add tag" opens a dropdown/popover listing unselected tags; clicking assigns.
+- Typing in the dropdown filters existing tags; if no match shows "Create new tag: [name]" option that opens a color-picker inline → `POST /Tag` → adds to selection.
+
+Used in the `CreateTrackedTaskForm` and edit modal.
+
+### 1.10 Client — Filter chips on TrackedTasks page
+
+- Above the task list, a row of tag filter chips (one per user tag).
+- Clicking a chip toggles it active (highlighted border + tinted background).
+- Active tag IDs are passed as `tagIds` query params to the existing search logic.
+- Empty selection = no tag filter (show all tasks).
+
+---
+
+## 2. Tech-Debt Sweep
+
+### 2.1 DB Indexes
+
+All added via `OnModelCreating` in `ApplicationDbContext`. A single migration covers all index additions.
+
+#### `TrackedTask`
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Non-unique | `UserId` | Every list/search/analytics query filters by `UserId` |
+| Non-unique | `ProjectId` | Project detail queries and cascade-delete scan |
+| Composite non-unique | `(UserId, StartDate DESC)` | Analytics date-range queries on the dashboard |
+
+```csharp
+builder.Entity<TrackedTask>().HasIndex(t => t.UserId);
+builder.Entity<TrackedTask>().HasIndex(t => t.ProjectId);
+builder.Entity<TrackedTask>().HasIndex(t => new { t.UserId, t.StartDate });
+```
+
+#### `Project`
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Non-unique | `UserId` | All project list/search queries |
+
+```csharp
+builder.Entity<Project>().HasIndex(p => p.UserId);
+```
+
+### 2.2 Unique Constraint — Project Names Per User
+
+Filtered unique index: duplicate project name is only blocked when both rows have `DeletedAt == null`. Soft-deleted projects do not consume a name slot.
+
+```csharp
+builder.Entity<Project>()
+    .HasIndex(p => new { p.UserId, p.Name })
+    .IsUnique()
+    .HasFilter("[DeletedAt] IS NULL");
+```
+
+**Controller change** (`ProjectController.CreateProject` and `UpdateProject`): wrap the `Insert`/`Update` call in a `try/catch` for `DbUpdateException` with a unique-constraint violation inner message; return `409 Conflict` with a user-friendly message `"A project with this name already exists."`.
+
+---
+
+## 3. Testing
+
+### Server.Tests
+
+- `TagController` unit tests: create, read, update, delete (no force → task count returned), delete with force → tags detached.
+- Duplicate tag name → 409.
+- Tag ownership: cannot read/edit/delete another user's tag.
+- Task create/update with `TagIds`: tags are attached; unowned tag IDs are silently skipped (only tags matching `userId` filter are loaded).
+- `TrackedTaskController.SearchTrackedTasks` with `tagIds`: OR filter returns correct tasks.
+- Project unique constraint: second create with same name returns 409; soft-deleted project name can be reused.
+
+### Client.Tests
+
+- `TagPicker` component: renders selected tags, remove pill updates `SelectedTagIds`, selecting from dropdown adds to list.
+
+---
+
+## 4. Migration
+
+One EF migration covers all schema changes:
+
+- New `Tags` table
+- New `TaskTag` join table
+- New indexes on `TrackedTask` and `Project`
+- New filtered unique index on `Project (UserId, Name)`
+
+Migration is auto-applied on startup (existing `MigrateAsync` gate in `Program.cs`).
+
+---
+
+## 5. Out of Scope (v2.2)
+
+- Tag-based analytics / charts
+- Bulk tag assignment across multiple tasks
+- Tag import/export
+- Tags on Projects (only TrackedTask for now)

--- a/docs/superpowers/specs/2026-06-02-v2.2-tags-techdebt-design.md
+++ b/docs/superpowers/specs/2026-06-02-v2.2-tags-techdebt-design.md
@@ -70,7 +70,7 @@ builder.Entity<Tag>()
     .HasOne(t => t.User)
     .WithMany(u => u.Tags)
     .HasForeignKey(t => t.UserId)
-    .OnDelete(DeleteBehavior.Cascade);
+    .OnDelete(DeleteBehavior.Restrict);
 
 builder.Entity<TrackedTask>()
     .HasMany(t => t.Tags)
@@ -104,10 +104,12 @@ All endpoints require `[Authorize]`. User identity resolved via `User.FindFirstV
 | GET | `/Tag` | Returns all tags for current user, ordered by `Name`. |
 | GET | `/Tag/{id}` | Returns single tag; 404 if not found or not owned by current user. |
 | POST | `/Tag` | Creates tag from `CreateTagDto`. Returns 409 with `{ message }` if name already exists for user. |
-| PUT | `/Tag` | Updates tag from `UpdateTagDto`. Same 409 conflict check. |
+| PUT | `/Tag/{id}` | Updates tag from `UpdateTagDto` (`id` must match `TagId` in payload). Same 409 conflict check. |
 | DELETE | `/Tag/{id}` | If `?force=false` (default): returns 200 `{ taskCount }` without deleting — client uses this to show the warning modal. If `?force=true`: deletes the `Tag` row (EF cascade removes `TaskTag` join rows). Returns 204. |
 
-Uses `IRepository<Tag>` via `RepositoryFactory`. The `force=false` task count is obtained by loading the tag with `includeProperties: "TrackedTasks"` and returning `tag.TrackedTasks.Count`.
+Uses `IRepository<Tag>` via `RepositoryFactory` plus direct EF projection for counts:
+- GET endpoints project `TaskCount` server-side via `t.TrackedTasks.Count()` (no eager-loading of full task collections).
+- `force=false` delete preview counts associated tasks with `IgnoreQueryFilters()` so soft-deleted (restorable) tasks are included in the warning.
 
 ### 1.5 Delete Behaviour
 


### PR DESCRIPTION
## Summary
- implement v2.2 server-side tags/labels with user scoping, tag CRUD, tracked-task tag support, and schema/index tech-debt sweep
- add client tags experience: /tags management page, nav integration, reusable TagPicker, task form integration, and tracked-task tag filter chips
- add regression coverage in server tests and bUnit coverage for TagPicker

## Commits
- docs(plan): add v2.2 tags-techdebt implementation steps
- feat(server): add user-scoped tags and v2.2 data constraints
- feat(client): add tags pages, picker, and tracked-task filters
- test(client): add bUnit TagPicker component coverage