### PR TITLE
fix: PR #48 review follow-ups — ProjectId input hardening

### DIFF
--- a/Timinute/Client/Services/AnalyticsService.cs
+++ b/Timinute/Client/Services/AnalyticsService.cs
@@ -24,7 +24,7 @@ namespace Timinute.Client.Services
 
         public event Action? Invalidated;
 
-        // Cache dictionary is small (bounded below) but never allowed to grow
+        // Cache dictionary is bounded above by MaxCacheEntries so it never grows
         // unbounded across a long session.
         private const int MaxCacheEntries = 50;
 

--- a/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
+++ b/Timinute/Server.Tests/Controllers/TrackedTaskControllerTest.cs
@@ -17,6 +17,7 @@ using Timinute.Server.Models;
 using Timinute.Server.Models.Paging;
 using Timinute.Server.Repository;
 using Timinute.Server.Tests.Helpers;
+using Timinute.Shared.Dtos.Project;
 using Timinute.Shared.Dtos.TrackedTask;
 using Timinute.Shared.Dtos.Trash;
 using Xunit;
@@ -613,6 +614,130 @@ namespace Timinute.Server.Tests.Controllers
             var created = okResult!.Value as TrackedTaskDto;
             Assert.NotNull(created);
             Assert.Equal("ProjectId1", created!.ProjectId);
+        }
+
+        [Fact]
+        public async Task Create_TrackedTask_With_Whitespace_ProjectId_Persists_Null_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "CreateWhitespaceProject");
+            TrackedTaskController controller = await CreateController(applicationDbContext); // ApplicationUser1
+
+            var trackedTaskToCreate = new CreateTrackedTaskDto
+            {
+                Name = "Whitespace Project Task",
+                StartDate = DateTimeOffset.UtcNow,
+                Duration = TimeSpan.FromHours(1),
+                ProjectId = "   " // whitespace must not reach the ProjectId FK column
+            };
+
+            var actionResult = await controller.CreateTrackedTask(trackedTaskToCreate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var persisted = await applicationDbContext.TrackedTasks.FirstOrDefaultAsync(t => t.Name == "Whitespace Project Task");
+            Assert.NotNull(persisted);
+            Assert.Null(persisted!.ProjectId);
+        }
+
+        [Fact]
+        public async Task Update_TrackedTask_With_Whitespace_ProjectId_Persists_Null_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateWhitespaceProject");
+            TrackedTaskController controller = await CreateController(applicationDbContext); // ApplicationUser1
+
+            var trackedTaskToUpdate = new UpdateTrackedTaskDto
+            {
+                TaskId = "TrackedTaskId1", // owned by ApplicationUser1, currently on ProjectId1
+                Name = "Task 1",
+                StartDate = DateTimeOffset.UtcNow,
+                ProjectId = "   " // whitespace must clear the project, not hit the FK
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(trackedTaskToUpdate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var persisted = await applicationDbContext.TrackedTasks.FirstOrDefaultAsync(t => t.TaskId == "TrackedTaskId1");
+            Assert.NotNull(persisted);
+            Assert.Null(persisted!.ProjectId);
+        }
+
+        [Fact]
+        public async Task Create_TrackedTask_With_Trailing_Space_ProjectId_Persists_Trimmed_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "CreateTrailingSpaceProject");
+            TrackedTaskController controller = await CreateController(applicationDbContext); // ApplicationUser1
+
+            var trackedTaskToCreate = new CreateTrackedTaskDto
+            {
+                Name = "Trailing Space Task",
+                StartDate = DateTimeOffset.UtcNow,
+                Duration = TimeSpan.FromHours(1),
+                ProjectId = "ProjectId1 " // SQL Server trailing-space padding would match; must be trimmed before persisting
+            };
+
+            var actionResult = await controller.CreateTrackedTask(trackedTaskToCreate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var persisted = await applicationDbContext.TrackedTasks.FirstOrDefaultAsync(t => t.Name == "Trailing Space Task");
+            Assert.NotNull(persisted);
+            Assert.Equal("ProjectId1", persisted!.ProjectId);
+        }
+
+        [Fact]
+        public async Task Create_TrackedTask_With_Nested_Project_Dto_Is_Ignored_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "CreateNestedProject");
+            TrackedTaskController controller = await CreateController(applicationDbContext); // ApplicationUser1
+
+            var trackedTaskToCreate = new CreateTrackedTaskDto
+            {
+                Name = "Nested Project Task",
+                StartDate = DateTimeOffset.UtcNow,
+                Duration = TimeSpan.FromHours(1),
+                ProjectId = null,
+                Project = new ProjectDto { ProjectId = "InjectedProjectId", Name = "Injected Project" }
+            };
+
+            var actionResult = await controller.CreateTrackedTask(trackedTaskToCreate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var persisted = await applicationDbContext.TrackedTasks.FirstOrDefaultAsync(t => t.Name == "Nested Project Task");
+            Assert.NotNull(persisted);
+            Assert.Null(persisted!.ProjectId);
+            Assert.False(await applicationDbContext.Projects.AnyAsync(p => p.ProjectId == "InjectedProjectId"));
+        }
+
+        [Fact]
+        public async Task Update_TrackedTask_With_Nested_Project_Dto_Is_Ignored_Test()
+        {
+            ApplicationDbContext applicationDbContext = await TestHelper.GetDefaultApplicationDbContext(_databaseName + "UpdateNestedProject");
+            TrackedTaskController controller = await CreateController(applicationDbContext); // ApplicationUser1
+
+            var trackedTaskToUpdate = new UpdateTrackedTaskDto
+            {
+                TaskId = "TrackedTaskId1", // owned by ApplicationUser1, currently on ProjectId1
+                Name = "Task 1",
+                StartDate = DateTimeOffset.UtcNow,
+                ProjectId = "ProjectId1",
+                Project = new ProjectDto { ProjectId = "InjectedProjectId", Name = "Injected Project" }
+            };
+
+            var actionResult = await controller.UpdateTrackedTask(trackedTaskToUpdate);
+
+            Assert.NotNull(actionResult);
+            Assert.IsAssignableFrom<OkObjectResult>(actionResult.Result);
+
+            var persisted = await applicationDbContext.TrackedTasks.FirstOrDefaultAsync(t => t.TaskId == "TrackedTaskId1");
+            Assert.NotNull(persisted);
+            Assert.Equal("ProjectId1", persisted!.ProjectId);
+            Assert.False(await applicationDbContext.Projects.AnyAsync(p => p.ProjectId == "InjectedProjectId"));
         }
 
         [Fact]

--- a/Timinute/Server/Controllers/TrackedTaskController.cs
+++ b/Timinute/Server/Controllers/TrackedTaskController.cs
@@ -147,6 +147,10 @@ namespace Timinute.Server.Controllers
                 return Unauthorized();
             }
 
+            // Whitespace means "no project"; trim otherwise — SQL Server's trailing-space padding would
+            // let "ProjectId1 " pass the ownership check and persist untrimmed in the FK column.
+            trackedTask.ProjectId = string.IsNullOrWhiteSpace(trackedTask.ProjectId) ? null : trackedTask.ProjectId.Trim();
+
             if (!await ProjectBelongsToUserAsync(userId, trackedTask.ProjectId))
             {
                 return NotFound("Project not found!");
@@ -281,6 +285,10 @@ namespace Timinute.Server.Controllers
                 logger.LogError("Tracked task was not found");
                 return NotFound("Tracked task not found!");
             }
+
+            // Whitespace means "no project"; trim otherwise — SQL Server's trailing-space padding would
+            // let "ProjectId1 " pass the ownership check and persist untrimmed in the FK column.
+            trackedTask.ProjectId = string.IsNullOrWhiteSpace(trackedTask.ProjectId) ? null : trackedTask.ProjectId.Trim();
 
             if (!await ProjectBelongsToUserAsync(userId, trackedTask.ProjectId))
             {

--- a/Timinute/Server/MappingProfile.cs
+++ b/Timinute/Server/MappingProfile.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Timinute.Server.Models;
 using Timinute.Shared.Dtos;
 using Timinute.Shared.Dtos.Project;
@@ -16,10 +16,14 @@ namespace Timinute.Server
             CreateMap<TrackedTaskDto, TrackedTask>();
 
             CreateMap<TrackedTask, CreateTrackedTaskDto>();
-            CreateMap<CreateTrackedTaskDto, TrackedTask>();
+            CreateMap<CreateTrackedTaskDto, TrackedTask>()
+                // Project is linked via the ownership-checked ProjectId only; mapping the nested
+                // DTO would attach a client-supplied Project entity to the insert graph.
+                .ForMember(d => d.Project, o => o.Ignore());
 
             CreateMap<TrackedTask, UpdateTrackedTaskDto>();
-            CreateMap<UpdateTrackedTaskDto, TrackedTask>();
+            CreateMap<UpdateTrackedTaskDto, TrackedTask>()
+                .ForMember(d => d.Project, o => o.Ignore());
 
             // Project model
             CreateMap<Project, ProjectDto>();

--- a/docs/superpowers/plans/done/2026-07-12-v2.3-analytics-techdebt.md
+++ b/docs/superpowers/plans/done/2026-07-12-v2.3-analytics-techdebt.md
@@ -1,5 +1,7 @@
 # v2.3 Enhanced Analytics + Tech-Debt Sweep Implementation Plan
 
+> **Status:** ✅ Shipped — merged to `develop` via PR #48 (2026-07-13); post-merge review follow-ups (whitespace/trailing-space `ProjectId` normalization, nested `Project` DTO map ignore) landed via PR #49. Tasks 1–12 completed (checkboxes below were not ticked during execution). All five carried-over tech-debt items shipped; a pre-existing `ProjectId` ownership leak was found and fixed along the way.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add range-based analytics (4 server aggregate endpoints + `/analytics` page + Dashboard retrofit off its load-all-tasks pattern) plus the five tech-debt items carried from v2.2.


### PR DESCRIPTION
Addresses the two Copilot review comments on #48 (which was merged before they were resolved — apologies), plus two adjacent findings from the `ef-repository-reviewer` pass on the fix.

## Changes

- **Whitespace `ProjectId` → FK violation 500** (Copilot, `TrackedTaskController.cs`): `ProjectBelongsToUserAsync` treated whitespace as "no project" but the mapped entity still carried the whitespace string into the FK column. Now normalized to `null` before the ownership guard and mapping, in both Create and Update.
- **Trailing-space `ProjectId`** (reviewer): SQL Server's ANSI trailing-space padding lets `"ProjectId1 "` pass the ownership check and persist untrimmed, which the client-side ordinal `GroupBy` in analytics then buckets as a separate project. Non-whitespace values are now trimmed.
- **Nested `Project` DTO graph injection** (reviewer, pre-existing): the inbound AutoMapper maps mapped `CreateTrackedTaskDto.Project`/`UpdateTrackedTaskDto.Project` by convention, attaching a client-supplied `Project` entity to the insert graph → constraint-violation 500. Both inbound maps now `.Ignore()` the member; projects are linked exclusively via the ownership-checked `ProjectId`.
- **Comment typo** (Copilot, `AnalyticsService.cs`): cache is bounded *above* by `MaxCacheEntries`, not "bounded below".

## Tests

5 new TDD tests (all written failing first): whitespace `ProjectId` persists as `null` (Create + Update), trailing-space persists trimmed, nested `Project` DTO is ignored (Create + Update). Full suite: **194 green** (167 server / 27 client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)